### PR TITLE
Integrate Wallaby

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -15,8 +15,18 @@ module.exports = {
   setupFiles: ['./theatre/shared/src/setupTestEnv.ts'],
   automock: false,
   transform: {
-    '^.+\\.tsx?$': 'esbuild-jest',
-    '^.+\\.js$': 'esbuild-jest',
+    '^.+\\.tsx?$': [
+      'esbuild-jest',
+      {
+        sourcemap: true,
+      },
+    ],
+    '^.+\\.js$': [
+      'esbuild-jest',
+      {
+        sourcemap: true,
+      },
+    ],
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
 }

--- a/packages/dataverse/src/utils/Emitter.test.ts
+++ b/packages/dataverse/src/utils/Emitter.test.ts
@@ -1,6 +1,6 @@
 import Emitter from './Emitter'
 
-describe.only('DataVerse.Emitter', () => {
+describe('DataVerse.Emitter', () => {
   it('should work', () => {
     const e: Emitter<string> = new Emitter()
     e.emit('no one will see this')

--- a/theatre/shared/src/utils/numberRoundingUtils.test.ts
+++ b/theatre/shared/src/utils/numberRoundingUtils.test.ts
@@ -68,11 +68,11 @@ describe(`numberRoundingUtils()`, () => {
         sign
       )
     }
-    for (let i = 0; i < 2000; i++) {
-      const from = toPrecision(getRandomNumber())
-      const to = toPrecision(getRandomNumber())
+    test(`roundestNumberBetween() => fuzzy`, () => {
+      for (let i = 0; i < 2000; i++) {
+        const from = toPrecision(getRandomNumber())
+        const to = toPrecision(getRandomNumber())
 
-      test(`roundestNumberBetween(${from}, ${to}) => fuzzy`, () => {
         const result = roundestNumberBetween(from, to)
         if (from < to) {
           if (result < from || result > to) {
@@ -83,8 +83,8 @@ describe(`numberRoundingUtils()`, () => {
             throw new Error(`Invalid: ${to} ${from} ${result}`)
           }
         }
-      })
-    }
+      }
+    })
   })
   describe(`roundestIntegerBetween`, () => {
     example(roundestIntegerBetween, [-1, 6], 0, {})

--- a/wallaby.conf.js
+++ b/wallaby.conf.js
@@ -1,0 +1,13 @@
+module.exports = () => {
+  return {
+    autoDetect: true,
+    tests: [
+      'theatre/**/*.test.ts',
+      'packages/dataverse/**/*.test.ts',
+      '!**/node_modules/**',
+    ],
+    testFramework: {
+      configFile: './jest.config.js',
+    },
+  }
+}


### PR DESCRIPTION
- Add Wallaby config
- Modify Jest config to generate source maps for the transformed sources
- Remove .only modifier from the Emitter test
- Put the fuzzy test loop inside a single test so we don't see 500000 unique test reports after a few minutes