### PR TITLE
Adding eslint-plugin-react-hooks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   root: true,
   plugins: ['unused-imports', 'eslint-plugin-tsdoc'],
-  extends: [],
+  extends: ['plugin:react-hooks/recommended'],
   rules: {
     'unused-imports/no-unused-imports': 'warn',
     'tsdoc/syntax': 'warn',

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eslint": "^7.32.0",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-react": "^7.25.1",
-    "eslint-plugin-react-hooks": "^4.2.0",
+    "eslint-plugin-react-hooks": "^4.3.0",
     "eslint-plugin-tsdoc": "^0.2.14",
     "eslint-plugin-unused-imports": "^1.1.4",
     "husky": "^6.0.0",

--- a/packages/r3f/src/components/EditorHelper.tsx
+++ b/packages/r3f/src/components/EditorHelper.tsx
@@ -11,9 +11,8 @@ const EditorHelper = <T extends ElementType>({
   component: Component,
   ...props
 }: EditorHelperProps<T>) => {
+  const helpersRoot = useEditorStore((state) => state.helpersRoot)
   if (process.env.NODE_ENV === 'development') {
-    const helpersRoot = useEditorStore((state) => state.helpersRoot)
-
     return <>{createPortal(<Component {...props} />, helpersRoot)}</>
   } else {
     return null

--- a/yarn.lock
+++ b/yarn.lock
@@ -11116,6 +11116,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-react-hooks@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "eslint-plugin-react-hooks@npm:4.3.0"
+  peerDependencies:
+    eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
+  checksum: 55d65863c0aeebbb470c494fe7fdf014b661c5aef21d1ab0c4f19b291d28b2a905de78eb6133891e4677abb7bc37c8b4a252aef007de1559ae28ad70e57d494a
+  languageName: node
+  linkType: hard
+
 "eslint-plugin-react@npm:^7.21.5":
   version: 7.24.0
   resolution: "eslint-plugin-react@npm:7.24.0"
@@ -22880,7 +22889,7 @@ fsevents@^1.2.7:
     eslint: ^7.32.0
     eslint-plugin-jsx-a11y: ^6.4.1
     eslint-plugin-react: ^7.25.1
-    eslint-plugin-react-hooks: ^4.2.0
+    eslint-plugin-react-hooks: ^4.3.0
     eslint-plugin-tsdoc: ^0.2.14
     eslint-plugin-unused-imports: ^1.1.4
     husky: ^6.0.0


### PR DESCRIPTION
Adding [eslint-plugin-react-hooks](https://www.npmjs.com/package/eslint-plugin-react-hooks) to improve code consistency, easier readability and ensure bugs are caught before making it to production.

I've left this at the default settings, but this can be tweaked over time. 

It currently is warning us of quite a few (~50) issues related to `react-hooks/exhaustive-deps`. My suggestions is that we address these incrementally rather than in one go.

