### PR TITLE
Fix keyframe pasting to respect interpolation graph

### DIFF
--- a/theatre/core/src/propTypes/index.ts
+++ b/theatre/core/src/propTypes/index.ts
@@ -506,7 +506,7 @@ export function stringLiteral<Opts extends {[key in string]: string}>(
 export type Sanitizer<T> = (value: unknown) => T | undefined
 export type Interpolator<T> = (left: T, right: T, progression: number) => T
 
-interface IBasePropType<ValueType, PropTypes = ValueType> {
+export interface IBasePropType<ValueType, PropTypes = ValueType> {
   valueType: ValueType
   [propTypeSymbol]: 'TheatrePropType'
   label: string | undefined

--- a/theatre/core/src/sheetObjects/SheetObject.ts
+++ b/theatre/core/src/sheetObjects/SheetObject.ts
@@ -23,7 +23,7 @@ import {Atom, getPointerParts, pointer, prism, val} from '@theatre/dataverse'
 import type SheetObjectTemplate from './SheetObjectTemplate'
 import TheatreSheetObject from './TheatreSheetObject'
 import type {Interpolator} from '@theatre/core/propTypes'
-import {getPropConfigByPath} from '@theatre/shared/propTypes/utils'
+import {getPropConfigByPath, valueInProp} from '@theatre/shared/propTypes/utils'
 
 // type Everything = {
 //   final: SerializableMap
@@ -159,7 +159,6 @@ export default class SheetObject implements IdentityDerivationProvider {
               pathToProp,
             )!
 
-            const sanitize = propConfig.sanitize!
             const interpolate =
               propConfig.interpolate! as Interpolator<$IntentionalAny>
 
@@ -169,21 +168,12 @@ export default class SheetObject implements IdentityDerivationProvider {
               if (!triple)
                 return valsAtom.setIn(pathToProp, propConfig!.default)
 
-              const leftSanitized = sanitize(triple.left)
-
-              const left =
-                typeof leftSanitized === 'undefined'
-                  ? propConfig.default
-                  : leftSanitized
+              const left = valueInProp(triple.left, propConfig)
 
               if (triple.right === undefined)
                 return valsAtom.setIn(pathToProp, left)
 
-              const rightSanitized = sanitize(triple.right)
-              const right =
-                typeof rightSanitized === 'undefined'
-                  ? propConfig.default
-                  : rightSanitized
+              const right = valueInProp(triple.right, propConfig)
 
               return valsAtom.setIn(
                 pathToProp,

--- a/theatre/shared/src/propTypes/utils.ts
+++ b/theatre/shared/src/propTypes/utils.ts
@@ -30,8 +30,8 @@ export function getPropConfigByPath(
 }
 
 /**
- * @param value An arbitrary value. May be matching the prop's type or not
- * @param propConfig The configuration object for a prop
+ * @param value - An arbitrary value. May be matching the prop's type or not
+ * @param propConfig - The configuration object for a prop
  * @returns value if it matches the prop's type, otherwise returns the default value for the prop
  */
 export function valueInProp(value: unknown, propConfig: PropTypeConfig) {

--- a/theatre/shared/src/propTypes/utils.ts
+++ b/theatre/shared/src/propTypes/utils.ts
@@ -28,3 +28,12 @@ export function getPropConfigByPath(
 
   return getPropConfigByPath(sub, rest)
 }
+
+export function valueInProp(value: unknown, propConfig: PropTypeConfig) {
+  const sanitizedVal = propConfig.sanitize!(value)
+  if (typeof sanitizedVal === 'undefined') {
+    return propConfig.default
+  } else {
+    return sanitizedVal
+  }
+}

--- a/theatre/shared/src/propTypes/utils.ts
+++ b/theatre/shared/src/propTypes/utils.ts
@@ -1,6 +1,8 @@
 import type {
+  IBasePropType,
   PropTypeConfig,
   PropTypeConfig_Compound,
+  PropTypeConfig_Number,
   PropTypeConfig_Enum,
 } from '@theatre/core/propTypes'
 import type {PathToProp} from '@theatre/shared/utils/addresses'
@@ -10,6 +12,12 @@ export function isPropConfigComposite(
   c: PropTypeConfig,
 ): c is PropTypeConfig_Compound<{}> | PropTypeConfig_Enum {
   return c.type === 'compound' || c.type === 'enum'
+}
+
+export function isPropConfigScalar(
+  propConfig: PropTypeConfig,
+): propConfig is PropTypeConfig_Number {
+  return propConfig.isScalar === true
 }
 
 export function getPropConfigByPath(
@@ -34,8 +42,14 @@ export function getPropConfigByPath(
  * @param propConfig - The configuration object for a prop
  * @returns value if it matches the prop's type, otherwise returns the default value for the prop
  */
-export function valueInProp(value: unknown, propConfig: PropTypeConfig) {
-  const sanitizedVal = propConfig.sanitize!(value)
+export function valueInProp<PropValueType>(
+  value: unknown,
+  propConfig: IBasePropType<PropValueType>,
+): PropValueType {
+  const sanitize = propConfig.sanitize
+  if (!sanitize) return propConfig.default
+
+  const sanitizedVal = sanitize(value)
   if (typeof sanitizedVal === 'undefined') {
     return propConfig.default
   } else {

--- a/theatre/shared/src/propTypes/utils.ts
+++ b/theatre/shared/src/propTypes/utils.ts
@@ -29,6 +29,11 @@ export function getPropConfigByPath(
   return getPropConfigByPath(sub, rest)
 }
 
+/**
+ * @param value An arbitrary value. May be matching the prop's type or not
+ * @param propConfig The configuration object for a prop
+ * @returns value if it matches the prop's type, otherwise returns the default value for the prop
+ */
 export function valueInProp(value: unknown, propConfig: PropTypeConfig) {
   const sanitizedVal = propConfig.sanitize!(value)
   if (typeof sanitizedVal === 'undefined') {

--- a/theatre/shared/src/propTypes/utils.ts
+++ b/theatre/shared/src/propTypes/utils.ts
@@ -2,7 +2,6 @@ import type {
   IBasePropType,
   PropTypeConfig,
   PropTypeConfig_Compound,
-  PropTypeConfig_Number,
   PropTypeConfig_Enum,
 } from '@theatre/core/propTypes'
 import type {PathToProp} from '@theatre/shared/utils/addresses'
@@ -12,12 +11,6 @@ export function isPropConfigComposite(
   c: PropTypeConfig,
 ): c is PropTypeConfig_Compound<{}> | PropTypeConfig_Enum {
   return c.type === 'compound' || c.type === 'enum'
-}
-
-export function isPropConfigScalar(
-  propConfig: PropTypeConfig,
-): propConfig is PropTypeConfig_Number {
-  return propConfig.isScalar === true
 }
 
 export function getPropConfigByPath(
@@ -40,14 +33,15 @@ export function getPropConfigByPath(
 /**
  * @param value - An arbitrary value. May be matching the prop's type or not
  * @param propConfig - The configuration object for a prop
- * @returns value if it matches the prop's type, otherwise returns the default value for the prop
+ * @returns value if it matches the prop's type (or if the prop doesn't have a sanitizer),
+ * otherwise returns the default value for the prop
  */
 export function valueInProp<PropValueType>(
   value: unknown,
   propConfig: IBasePropType<PropValueType>,
-): PropValueType {
+): PropValueType | unknown {
   const sanitize = propConfig.sanitize
-  if (!sanitize) return propConfig.default
+  if (!sanitize) return value
 
   const sanitizedVal = sanitize(value)
   if (typeof sanitizedVal === 'undefined') {

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/BasicKeyframedTrack.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/BasicKeyframedTrack.tsx
@@ -118,6 +118,7 @@ function pasteKeyframesContextMenuItem(
               ...props.leaf.sheetObject.address,
               trackId: props.leaf.trackId,
               position: sequence.position + keyframe.position - keyframeOffset,
+              handles: keyframe.handles,
               value: keyframe.value,
               snappingFunction: sequence.closestGridPosition,
             },

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/KeyframeEditor/Dot.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/KeyframeEditor/Dot.tsx
@@ -107,17 +107,19 @@ const Dot: React.FC<IProps> = (props) => {
 export default Dot
 
 function useKeyframeContextMenu(node: HTMLDivElement | null, props: IProps) {
-  const maybeKeyframeIds = selectedKeyframeIdsIfInSingleTrack(props.selection)
+  const maybeSelectedKeyframeIds = selectedKeyframeIdsIfInSingleTrack(
+    props.selection,
+  )
 
-  const keyframeSelectionItems = maybeKeyframeIds
-    ? [copyKeyFrameContextMenuItem(props, maybeKeyframeIds)]
-    : []
+  const keyframeSelectionItem = maybeSelectedKeyframeIds
+    ? copyKeyFrameContextMenuItem(props, maybeSelectedKeyframeIds)
+    : copyKeyFrameContextMenuItem(props, [props.keyframe.id])
 
   const deleteItem = deleteSelectionOrKeyframeContextMenuItem(props)
 
   return useContextMenu(node, {
     items: () => {
-      return [...keyframeSelectionItems, deleteItem]
+      return [keyframeSelectionItem, deleteItem]
     },
   })
 }
@@ -263,7 +265,7 @@ function deleteSelectionOrKeyframeContextMenuItem(props: IProps) {
 
 function copyKeyFrameContextMenuItem(props: IProps, keyframeIds: string[]) {
   return {
-    label: 'Copy Keyframes',
+    label: keyframeIds.length > 1 ? 'Copy selection' : 'Copy keyframe',
     callback: () => {
       const keyframes = keyframeIds.map(
         (keyframeId) =>

--- a/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/BasicKeyframedTrack/BasicKeyframedTrack.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/BasicKeyframedTrack/BasicKeyframedTrack.tsx
@@ -11,12 +11,8 @@ import React, {useMemo, useRef, useState} from 'react'
 import type {SequenceEditorPanelLayout} from '@theatre/studio/panels/SequenceEditorPanel/layout/layout'
 import {graphEditorColors} from '@theatre/studio/panels/SequenceEditorPanel/GraphEditor/GraphEditor'
 import KeyframeEditor from './KeyframeEditor/KeyframeEditor'
-import {
-  getPropConfigByPath,
-  isPropConfigScalar,
-  valueInProp,
-} from '@theatre/shared/propTypes/utils'
-import type {PropTypeConfig_Number} from '@theatre/core/propTypes'
+import {getPropConfigByPath, valueInProp} from '@theatre/shared/propTypes/utils'
+import type {PropTypeConfig} from '@theatre/core/propTypes'
 
 export type ExtremumSpace = {
   fromValueSpace: (v: number) => number
@@ -58,9 +54,10 @@ const BasicKeyframedTrack: React.FC<{
     }, [])
 
     const extremumSpace: ExtremumSpace = useMemo(() => {
-      const extremums = isPropConfigScalar(propConfig)
-        ? calculateScalarExtremums(trackData.keyframes, propConfig)
-        : calculateNonScalarExtremums(trackData.keyframes)
+      const extremums =
+        propConfig.isScalar === true
+          ? calculateScalarExtremums(trackData.keyframes, propConfig)
+          : calculateNonScalarExtremums(trackData.keyframes)
 
       const fromValueSpace = (val: number): number =>
         (val - extremums[0]) / (extremums[1] - extremums[0])
@@ -121,7 +118,7 @@ type Extremums = [min: number, max: number]
 
 function calculateScalarExtremums(
   keyframes: Keyframe[],
-  propConfig: PropTypeConfig_Number,
+  propConfig: PropTypeConfig,
 ): Extremums {
   let min = Infinity,
     max = -Infinity
@@ -132,7 +129,7 @@ function calculateScalarExtremums(
   }
 
   keyframes.forEach((cur, i) => {
-    const curVal = valueInProp(cur.value, propConfig)
+    const curVal = valueInProp(cur.value, propConfig) as number
     check(curVal)
     if (!cur.connectedRight) return
     const next = keyframes[i + 1]

--- a/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/BasicKeyframedTrack/BasicKeyframedTrack.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/BasicKeyframedTrack/BasicKeyframedTrack.tsx
@@ -11,7 +11,8 @@ import React, {useMemo, useRef, useState} from 'react'
 import type {SequenceEditorPanelLayout} from '@theatre/studio/panels/SequenceEditorPanel/layout/layout'
 import {graphEditorColors} from '@theatre/studio/panels/SequenceEditorPanel/GraphEditor/GraphEditor'
 import KeyframeEditor from './KeyframeEditor/KeyframeEditor'
-import {getPropConfigByPath} from '@theatre/shared/propTypes/utils'
+import {getPropConfigByPath, valueInProp} from '@theatre/shared/propTypes/utils'
+import type {PropTypeConfig} from '@theatre/core/propTypes'
 
 export type ExtremumSpace = {
   fromValueSpace: (v: number) => number
@@ -55,7 +56,7 @@ const BasicKeyframedTrack: React.FC<{
     const extremumSpace: ExtremumSpace = useMemo(() => {
       const extremums =
         propConfig.isScalar === true
-          ? calculateScalarExtremums(trackData.keyframes)
+          ? calculateScalarExtremums(trackData.keyframes, propConfig)
           : calculateNonScalarExtremums(trackData.keyframes)
 
       const fromValueSpace = (val: number): number =>
@@ -84,6 +85,7 @@ const BasicKeyframedTrack: React.FC<{
 
     const keyframeEditors = trackData.keyframes.map((kf, index) => (
       <KeyframeEditor
+        propConfig={propConfig}
         keyframe={kf}
         index={index}
         trackData={trackData}
@@ -114,7 +116,10 @@ export default BasicKeyframedTrack
 
 type Extremums = [min: number, max: number]
 
-function calculateScalarExtremums(keyframes: Keyframe[]): Extremums {
+function calculateScalarExtremums(
+  keyframes: Keyframe[],
+  propConfig: PropTypeConfig,
+): Extremums {
   let min = Infinity,
     max = -Infinity
 
@@ -124,7 +129,7 @@ function calculateScalarExtremums(keyframes: Keyframe[]): Extremums {
   }
 
   keyframes.forEach((cur, i) => {
-    const curVal = typeof cur.value === 'number' ? cur.value : 0
+    const curVal = valueInProp(cur.value, propConfig)
     check(curVal)
     if (!cur.connectedRight) return
     const next = keyframes[i + 1]

--- a/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/BasicKeyframedTrack/BasicKeyframedTrack.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/BasicKeyframedTrack/BasicKeyframedTrack.tsx
@@ -11,8 +11,12 @@ import React, {useMemo, useRef, useState} from 'react'
 import type {SequenceEditorPanelLayout} from '@theatre/studio/panels/SequenceEditorPanel/layout/layout'
 import {graphEditorColors} from '@theatre/studio/panels/SequenceEditorPanel/GraphEditor/GraphEditor'
 import KeyframeEditor from './KeyframeEditor/KeyframeEditor'
-import {getPropConfigByPath, valueInProp} from '@theatre/shared/propTypes/utils'
-import type {PropTypeConfig} from '@theatre/core/propTypes'
+import {
+  getPropConfigByPath,
+  isPropConfigScalar,
+  valueInProp,
+} from '@theatre/shared/propTypes/utils'
+import type {PropTypeConfig_Number} from '@theatre/core/propTypes'
 
 export type ExtremumSpace = {
   fromValueSpace: (v: number) => number
@@ -54,10 +58,9 @@ const BasicKeyframedTrack: React.FC<{
     }, [])
 
     const extremumSpace: ExtremumSpace = useMemo(() => {
-      const extremums =
-        propConfig.isScalar === true
-          ? calculateScalarExtremums(trackData.keyframes, propConfig)
-          : calculateNonScalarExtremums(trackData.keyframes)
+      const extremums = isPropConfigScalar(propConfig)
+        ? calculateScalarExtremums(trackData.keyframes, propConfig)
+        : calculateNonScalarExtremums(trackData.keyframes)
 
       const fromValueSpace = (val: number): number =>
         (val - extremums[0]) / (extremums[1] - extremums[0])
@@ -118,7 +121,7 @@ type Extremums = [min: number, max: number]
 
 function calculateScalarExtremums(
   keyframes: Keyframe[],
-  propConfig: PropTypeConfig,
+  propConfig: PropTypeConfig_Number,
 ): Extremums {
   let min = Infinity,
     max = -Infinity

--- a/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/BasicKeyframedTrack/KeyframeEditor/Curve.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/BasicKeyframedTrack/KeyframeEditor/Curve.tsx
@@ -1,4 +1,4 @@
-import {valueInProp} from '@theatre/shared/propTypes/utils'
+import {isPropConfigScalar, valueInProp} from '@theatre/shared/propTypes/utils'
 import getStudio from '@theatre/studio/getStudio'
 import useContextMenu from '@theatre/studio/uiComponents/simpleContextMenu/useContextMenu'
 import useRefAndState from '@theatre/studio/utils/useRefAndState'
@@ -26,8 +26,10 @@ const Curve: React.FC<IProps> = (props) => {
 
   const [contextMenu] = useConnectorContextMenu(node, props)
 
-  const curValue = props.isScalar ? valueInProp(cur.value, props.propConfig) : 0
-  const nextValue = props.isScalar
+  const curValue = isPropConfigScalar(props.propConfig)
+    ? valueInProp(cur.value, props.propConfig)
+    : 0
+  const nextValue = isPropConfigScalar(props.propConfig)
     ? valueInProp(next.value, props.propConfig)
     : 1
   const leftYInExtremumSpace = props.extremumSpace.fromValueSpace(curValue)

--- a/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/BasicKeyframedTrack/KeyframeEditor/Curve.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/BasicKeyframedTrack/KeyframeEditor/Curve.tsx
@@ -1,4 +1,4 @@
-import {isPropConfigScalar, valueInProp} from '@theatre/shared/propTypes/utils'
+import {valueInProp} from '@theatre/shared/propTypes/utils'
 import getStudio from '@theatre/studio/getStudio'
 import useContextMenu from '@theatre/studio/uiComponents/simpleContextMenu/useContextMenu'
 import useRefAndState from '@theatre/studio/utils/useRefAndState'
@@ -26,11 +26,11 @@ const Curve: React.FC<IProps> = (props) => {
 
   const [contextMenu] = useConnectorContextMenu(node, props)
 
-  const curValue = isPropConfigScalar(props.propConfig)
-    ? valueInProp(cur.value, props.propConfig)
+  const curValue = props.isScalar
+    ? (valueInProp(cur.value, props.propConfig) as number)
     : 0
-  const nextValue = isPropConfigScalar(props.propConfig)
-    ? valueInProp(next.value, props.propConfig)
+  const nextValue = props.isScalar
+    ? (valueInProp(next.value, props.propConfig) as number)
     : 1
   const leftYInExtremumSpace = props.extremumSpace.fromValueSpace(curValue)
   const rightYInExtremumSpace = props.extremumSpace.fromValueSpace(nextValue)

--- a/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/BasicKeyframedTrack/KeyframeEditor/Curve.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/BasicKeyframedTrack/KeyframeEditor/Curve.tsx
@@ -1,3 +1,4 @@
+import {valueInProp} from '@theatre/shared/propTypes/utils'
 import getStudio from '@theatre/studio/getStudio'
 import useContextMenu from '@theatre/studio/uiComponents/simpleContextMenu/useContextMenu'
 import useRefAndState from '@theatre/studio/utils/useRefAndState'
@@ -25,8 +26,10 @@ const Curve: React.FC<IProps> = (props) => {
 
   const [contextMenu] = useConnectorContextMenu(node, props)
 
-  const curValue = props.isScalar ? (cur.value as number) : 0
-  const nextValue = props.isScalar ? (next.value as number) : 1
+  const curValue = props.isScalar ? valueInProp(cur.value, props.propConfig) : 0
+  const nextValue = props.isScalar
+    ? valueInProp(next.value, props.propConfig)
+    : 1
   const leftYInExtremumSpace = props.extremumSpace.fromValueSpace(curValue)
   const rightYInExtremumSpace = props.extremumSpace.fromValueSpace(nextValue)
 

--- a/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/BasicKeyframedTrack/KeyframeEditor/KeyframeEditor.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/BasicKeyframedTrack/KeyframeEditor/KeyframeEditor.tsx
@@ -15,6 +15,7 @@ import CurveHandle from './CurveHandle'
 import GraphEditorDotScalar from './GraphEditorDotScalar'
 import GraphEditorDotNonScalar from './GraphEditorDotNonScalar'
 import GraphEditorNonScalarDash from './GraphEditorNonScalarDash'
+import type {PropTypeConfig} from '@theatre/core/propTypes'
 
 const Container = styled.g`
   /* position: absolute; */
@@ -32,6 +33,7 @@ const KeyframeEditor: React.FC<{
   extremumSpace: ExtremumSpace
   isScalar: boolean
   color: keyof typeof graphEditorColors
+  propConfig: PropTypeConfig
 }> = (props) => {
   const {index, trackData, isScalar} = props
   const cur = trackData.keyframes[index]

--- a/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/GraphEditor.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/GraphEditor.tsx
@@ -113,9 +113,9 @@ const GraphEditor: React.FC<{
           >
             <g
               style={{
-                transform: `translate(0, ${val(
-                  layoutP.graphEditorDims.padding.top,
-                )}px)`,
+                transform: `translate(${val(
+                  layoutP.scaledSpace.leftPadding,
+                )}px, ${val(layoutP.graphEditorDims.padding.top)}px)`,
               }}
             >
               {graphs}

--- a/theatre/studio/src/store/stateEditors.ts
+++ b/theatre/studio/src/store/stateEditors.ts
@@ -523,6 +523,7 @@ namespace stateEditors {
             p: WithoutSheetInstance<SheetObjectAddress> & {
               trackId: string
               position: number
+              handles?: [number, number, number, number]
               value: T
               snappingFunction: SnappingFunction
             },
@@ -548,7 +549,7 @@ namespace stateEditors {
                 id: generateKeyframeId(),
                 position,
                 connectedRight: true,
-                handles: [0.5, 1, 0.5, 0],
+                handles: p.handles || [0.5, 1, 0.5, 0],
                 value: p.value,
               })
               return
@@ -558,7 +559,7 @@ namespace stateEditors {
               id: generateKeyframeId(),
               position,
               connectedRight: leftKeyframe.connectedRight,
-              handles: [0.5, 1, 0.5, 0],
+              handles: p.handles || [0.5, 1, 0.5, 0],
               value: p.value,
             })
           }


### PR DESCRIPTION
## Demo
Before the fix:
1. the curve is slightly horizontally offset from the keyframes 
2. the green y curve is copied from x, but does not match x's curve
3. the curve does not properly display default values when the keyframe has a type that does not match the track (not pictured)
<img width="341" alt="Screen Shot 2022-03-24 at 4 46 30 PM" src="https://user-images.githubusercontent.com/11082236/160007456-0c175931-c56b-4aed-baf6-00bac4de2e39.png">
after the fix:

1. the curve is correctly aligned with the keyframes
2. the green y is copied from x, and *does* match x
3. the curve correctly shows default values (not pictured)
<img width="340" alt="Screen Shot 2022-03-24 at 4 50 39 PM" src="https://user-images.githubusercontent.com/11082236/160008078-0222c9d3-d485-43b9-830e-94261fe7cae9.png">

## Note
- also adds 'copy keyframe' to a single keyframe's context menu. Missed this on the first pass.
