### PR TITLE
OutlinePanel: Display object list in A-Z order

### DIFF
--- a/theatre/studio/src/panels/OutlinePanel/ObjectsList/ObjectsList.tsx
+++ b/theatre/studio/src/panels/OutlinePanel/ObjectsList/ObjectsList.tsx
@@ -19,15 +19,17 @@ const ObjectsList: React.FC<{
 
     return (
       <>
-        {objectsEntries.map(([objectPath, object]) => {
-          return (
-            <ObjectItem
-              depth={depth}
-              key={'objectPath(' + objectPath + ')'}
-              sheetObject={object}
-            />
-          )
-        })}
+        {objectsEntries
+          .sort(([pathA], [pathB]) => (pathA > pathB ? 1 : -1))
+          .map(([objectPath, object]) => {
+            return (
+              <ObjectItem
+                depth={depth}
+                key={'objectPath(' + objectPath + ')'}
+                sheetObject={object}
+              />
+            )
+          })}
       </>
     )
   }, [sheet, depth])


### PR DESCRIPTION
Suggested as a minor UX improvement. For projects with many objects, alphabetical order feels easier to navigate (IMO) than creation order. Could also consider exposing a `sortOrder` config option on the `.object(name, config)` method, or a sort toggle in the UI, but just adding a default sort seemed like the simplest place to start. Thanks!

| before | after |
|---|---|
| ![before](https://user-images.githubusercontent.com/1848368/161077997-2261a74b-e740-484f-9dc9-3d31e88269e2.png) | ![after](https://user-images.githubusercontent.com/1848368/161078033-0e3d1752-3a6a-4928-894a-e79dd3f8fba2.png) |
 