### PR TITLE
Standardize handling of non-compound types

### DIFF
--- a/packages/dataverse/src/Atom.ts
+++ b/packages/dataverse/src/Atom.ts
@@ -299,7 +299,13 @@ function isIdentityChangeProvider(
  *
  * @param input - The argument to return a value from.
  */
-export const val = <P>(
+export const val = <
+  P extends
+    | PointerType<$IntentionalAny>
+    | IDerivation<$IntentionalAny>
+    | undefined
+    | null,
+>(
   input: P,
 ): P extends PointerType<infer T>
   ? T

--- a/packages/dataverse/src/Atom.ts
+++ b/packages/dataverse/src/Atom.ts
@@ -297,10 +297,10 @@ function isIdentityChangeProvider(
  * For pointers, the value is returned by first creating a derivation, so it is
  * reactive e.g. when used in a `prism`.
  *
- * @param pointerOrDerivationOrPlainValue - The argument to return a value from.
+ * @param input - The argument to return a value from.
  */
 export const val = <P>(
-  pointerOrDerivationOrPlainValue: P,
+  input: P,
 ): P extends PointerType<infer T>
   ? T
   : P extends IDerivation<infer T>
@@ -308,13 +308,11 @@ export const val = <P>(
   : P extends undefined | null
   ? P
   : unknown => {
-  if (isPointer(pointerOrDerivationOrPlainValue)) {
-    return valueDerivation(
-      pointerOrDerivationOrPlainValue,
-    ).getValue() as $IntentionalAny
-  } else if (isDerivation(pointerOrDerivationOrPlainValue)) {
-    return pointerOrDerivationOrPlainValue.getValue() as $IntentionalAny
+  if (isPointer(input)) {
+    return valueDerivation(input).getValue() as $IntentionalAny
+  } else if (isDerivation(input)) {
+    return input.getValue() as $IntentionalAny
   } else {
-    return pointerOrDerivationOrPlainValue as $IntentionalAny
+    return input as $IntentionalAny
   }
 }

--- a/packages/dataverse/src/index.ts
+++ b/packages/dataverse/src/index.ts
@@ -17,6 +17,6 @@ export {default as iterateAndCountTicks} from './derivations/iterateAndCountTick
 export {default as iterateOver} from './derivations/iterateOver'
 export {default as prism} from './derivations/prism/prism'
 export {default as pointer, getPointerParts, isPointer} from './pointer'
-export type {Pointer, PointerType} from './pointer'
+export type {Pointer, PointerType, OpaqueToPointers} from './pointer'
 export {default as Ticker} from './Ticker'
 export {default as PointerProxy} from './PointerProxy'

--- a/packages/dataverse/src/pointer.ts
+++ b/packages/dataverse/src/pointer.ts
@@ -39,6 +39,19 @@ export type PointerType<O> = {
  * explanation of pointers.
  *
  * @see Atom
+ *
+ * @remarks
+ * The Pointer type is quite tricky because it doesn't play well with `any` and other inexact types.
+ * Here is an example that one would expect to work, but currently doesn't:
+ * ```ts
+ * declare function expectAnyPointer(pointer: Pointer<any>): void
+ *
+ * expectAnyPointer(null as Pointer<{}>) // doesn't work
+ * ```
+ *
+ * The current solution is to just avoid using `any` with pointer-related code (or type-test it well).
+ * But if you enjoy solving typescript puzzles, consider fixing this :)
+ *
  */
 export type Pointer<O> = PointerType<O> &
   (O extends UnindexableTypesForPointer

--- a/packages/dataverse/src/pointer.ts
+++ b/packages/dataverse/src/pointer.ts
@@ -7,6 +7,10 @@ type PointerMeta = {
   path: (string | number)[]
 }
 
+const symbolForUnpointableTypes = Symbol()
+
+export type OpaqueToPointers = {[symbolForUnpointableTypes]: true}
+
 export type UnindexableTypesForPointer =
   | number
   | string
@@ -15,6 +19,7 @@ export type UnindexableTypesForPointer =
   | void
   | undefined
   | Function // eslint-disable-line @typescript-eslint/ban-types
+  | OpaqueToPointers
 
 export type UnindexablePointer = {
   [K in $IntentionalAny]: Pointer<undefined>

--- a/theatre/core/src/propTypes/index.ts
+++ b/theatre/core/src/propTypes/index.ts
@@ -17,6 +17,12 @@ import type {
 import {sanitizeCompoundProps} from './internals'
 import {propTypeSymbol} from './internals'
 
+// Notes on naming:
+// As of now, prop types are either `simple` or `composite`.
+// The compound type is a composite type. So is the upcoming enum type.
+// Composite types are not directly sequenceable yet. Their simple sub/ancestor props are.
+// We’ll provide a nice UX to manage keyframing of multiple sub-props.
+
 const validateCommonOpts = (fnCallSignature: string, opts?: CommonOpts) => {
   if (process.env.NODE_ENV !== 'production') {
     if (opts === undefined) return

--- a/theatre/core/src/sequences/interpolationTripleAtPosition.ts
+++ b/theatre/core/src/sequences/interpolationTripleAtPosition.ts
@@ -14,12 +14,12 @@ export type InterpolationTriple = {
   progression: number
 }
 
-// @remarks This new implementation supports sequencing non-scalars, but it's also heavier
+// @remarks This new implementation supports sequencing non-numeric props, but it's also heavier
 // on the GC. This shouldn't be a problem for the vast majority of users, but it's also a
 // low-hanging fruit for perf optimization.
 // It can be improved by:
 // 1. Not creating a new InterpolationTriple object on every change
-// 2. Caching propConfig.sanitize(value)
+// 2. Caching propConfig.deserialize(value)
 
 export default function interpolationTripleAtPosition(
   trackP: Pointer<TrackData | undefined>,

--- a/theatre/core/src/sheetObjects/SheetObject.test.ts
+++ b/theatre/core/src/sheetObjects/SheetObject.test.ts
@@ -4,11 +4,11 @@
 import {setupTestSheet} from '@theatre/shared/testUtils'
 import {encodePathToProp} from '@theatre/shared/utils/addresses'
 import {asKeyframeId, asSequenceTrackId} from '@theatre/shared/utils/ids'
-import {iterateOver, prism, val} from '@theatre/dataverse'
+import {iterateOver, prism} from '@theatre/dataverse'
 
 describe(`SheetObject`, () => {
   test('it should support setting/unsetting static props', async () => {
-    const {obj, studio} = await setupTestSheet({
+    const {studio, objPublicAPI} = await setupTestSheet({
       staticOverrides: {
         byObject: {
           obj: {
@@ -22,7 +22,7 @@ describe(`SheetObject`, () => {
 
     const objValues = iterateOver(
       prism(() => {
-        return val(val(obj.getValues()))
+        return objPublicAPI.value
       }),
     )
 
@@ -32,7 +32,7 @@ describe(`SheetObject`, () => {
 
     // setting a static
     studio.transaction(({set}) => {
-      set(obj.propsP.position.y, 5)
+      set(objPublicAPI.props.position.y, 5)
     })
 
     expect(objValues.next().value).toMatchObject({
@@ -41,7 +41,7 @@ describe(`SheetObject`, () => {
 
     // unsetting a static
     studio.transaction(({unset}) => {
-      unset(obj.propsP.position.y)
+      unset(objPublicAPI.props.position.y)
     })
 
     expect(objValues.next().value).toMatchObject({
@@ -52,7 +52,7 @@ describe(`SheetObject`, () => {
   })
 
   test('it should support sequenced props', async () => {
-    const {obj, sheet} = await setupTestSheet({
+    const {objPublicAPI, sheet} = await setupTestSheet({
       staticOverrides: {
         byObject: {},
       },
@@ -93,11 +93,7 @@ describe(`SheetObject`, () => {
 
     const seq = sheet.publicApi.sequence
 
-    const objValues = iterateOver(
-      prism(() => {
-        return val(val(obj.getValues()))
-      }),
-    )
+    const objValues = iterateOver(prism(() => objPublicAPI.value))
 
     expect(seq.position).toEqual(0)
 

--- a/theatre/core/src/sheetObjects/SheetObject.test.ts
+++ b/theatre/core/src/sheetObjects/SheetObject.test.ts
@@ -29,6 +29,7 @@ describe(`SheetObject`, () => {
     describe(`conformance`, () => {
       test(`invalid static overrides should get ignored`, async () => {
         const {teardown, objValues} = await setup({
+          nonExistentProp: 1,
           position: {
             // valid
             x: 10,
@@ -44,7 +45,8 @@ describe(`SheetObject`, () => {
             },
           },
         })
-        expect(objValues.next().value).toMatchObject({
+        const {value} = objValues.next()
+        expect(value).toMatchObject({
           position: {x: 10, y: 0, z: 0},
           color: {r: 0, g: 0, b: 0, a: 1},
           deeply: {
@@ -53,6 +55,7 @@ describe(`SheetObject`, () => {
             },
           },
         })
+        expect(value).not.toHaveProperty('nonExistentProp')
         teardown()
       })
     })

--- a/theatre/core/src/sheetObjects/SheetObject.test.ts
+++ b/theatre/core/src/sheetObjects/SheetObject.test.ts
@@ -58,6 +58,41 @@ describe(`SheetObject`, () => {
         expect(value).not.toHaveProperty('nonExistentProp')
         teardown()
       })
+
+      test(`setting a compound prop should only work if all its sub-props are present`, async () => {
+        const {teardown, objValues, objPublicAPI, studio} = await setup({})
+        expect(() => {
+          studio.transaction(({set}) => {
+            set(objPublicAPI.props.position, {x: 1, y: 2} as any as {
+              x: number
+              y: number
+              z: number
+            })
+          })
+        }).toThrow()
+      })
+
+      test(`setting a compound prop should only work if all its sub-props are valid`, async () => {
+        const {teardown, objValues, objPublicAPI, studio} = await setup({})
+        expect(() => {
+          studio.transaction(({set}) => {
+            set(objPublicAPI.props.position, {x: 1, y: 2, z: 'bad'} as any as {
+              x: number
+              y: number
+              z: number
+            })
+          })
+        }).toThrow()
+      })
+
+      test(`setting a simple prop should only work if it is valid`, async () => {
+        const {teardown, objValues, objPublicAPI, studio} = await setup({})
+        expect(() => {
+          studio.transaction(({set}) => {
+            set(objPublicAPI.props.position.x, 'bad' as any as number)
+          })
+        }).toThrow()
+      })
     })
 
     test(`should be a deep merge of default values and static overrides`, async () => {

--- a/theatre/core/src/sheetObjects/SheetObject.test.ts
+++ b/theatre/core/src/sheetObjects/SheetObject.test.ts
@@ -180,11 +180,11 @@ describe(`SheetObject`, () => {
         test(`should allow setting an override`, async () => {
           const {teardown, objValues, studio, objPublicAPI} = await setup()
           studio.transaction(({set}) => {
-            set(objPublicAPI.props.color, {r: 1, g: 2, b: 3, a: 0.5})
+            set(objPublicAPI.props.color, {r: 0.1, g: 0.2, b: 0.3, a: 0.5})
           })
 
           expect(objValues.next().value).toMatchObject({
-            color: {r: 1, g: 2, b: 3, a: 0.5},
+            color: {r: 0.1, g: 0.2, b: 0.3, a: 0.5},
           })
 
           teardown()
@@ -212,7 +212,7 @@ describe(`SheetObject`, () => {
         test(`should allow unsetting an override`, async () => {
           const {teardown, objValues, studio, objPublicAPI} = await setup()
           studio.transaction(({set}) => {
-            set(objPublicAPI.props.color, {r: 1, g: 2, b: 3, a: 0.5})
+            set(objPublicAPI.props.color, {r: 0.1, g: 0.2, b: 0.3, a: 0.5})
           })
 
           studio.transaction(({unset}) => {
@@ -229,7 +229,7 @@ describe(`SheetObject`, () => {
         test(`should disallow unsetting an override on sub-props`, async () => {
           const {teardown, objValues, studio, objPublicAPI} = await setup()
           studio.transaction(({set}) => {
-            set(objPublicAPI.props.color, {r: 1, g: 2, b: 3, a: 0.5})
+            set(objPublicAPI.props.color, {r: 0.1, g: 0.2, b: 0.3, a: 0.5})
           })
 
           // TODO: also disallow in types
@@ -240,7 +240,7 @@ describe(`SheetObject`, () => {
           }).toThrow()
 
           expect(objValues.next().value).toMatchObject({
-            color: {r: 1, g: 2, b: 3, a: 0.5},
+            color: {r: 0.1, g: 0.2, b: 0.3, a: 0.5},
           })
 
           teardown()

--- a/theatre/core/src/sheetObjects/SheetObject.test.ts
+++ b/theatre/core/src/sheetObjects/SheetObject.test.ts
@@ -95,77 +95,79 @@ describe(`SheetObject`, () => {
     })
   })
 
-  test('it should support sequenced props', async () => {
-    const {objPublicAPI, sheet} = await setupTestSheet({
-      staticOverrides: {
-        byObject: {},
-      },
-      sequence: {
-        type: 'PositionalSequence',
-        length: 20,
-        subUnitsPerUnit: 30,
-        tracksByObject: {
-          obj: {
-            trackIdByPropPath: {
-              [encodePathToProp(['position', 'y'])]: asSequenceTrackId('1'),
-            },
-            trackData: {
-              '1': {
-                type: 'BasicKeyframedTrack',
-                keyframes: [
-                  {
-                    id: asKeyframeId('0'),
-                    position: 10,
-                    connectedRight: true,
-                    handles: [0.5, 0.5, 0.5, 0.5],
-                    value: 3,
-                  },
-                  {
-                    id: asKeyframeId('1'),
-                    position: 20,
-                    connectedRight: false,
-                    handles: [0.5, 0.5, 0.5, 0.5],
-                    value: 6,
-                  },
-                ],
+  describe(`sequenced overrides`, () => {
+    test('calculation of sequenced overrides', async () => {
+      const {objPublicAPI, sheet} = await setupTestSheet({
+        staticOverrides: {
+          byObject: {},
+        },
+        sequence: {
+          type: 'PositionalSequence',
+          length: 20,
+          subUnitsPerUnit: 30,
+          tracksByObject: {
+            obj: {
+              trackIdByPropPath: {
+                [encodePathToProp(['position', 'y'])]: asSequenceTrackId('1'),
+              },
+              trackData: {
+                '1': {
+                  type: 'BasicKeyframedTrack',
+                  keyframes: [
+                    {
+                      id: asKeyframeId('0'),
+                      position: 10,
+                      connectedRight: true,
+                      handles: [0.5, 0.5, 0.5, 0.5],
+                      value: 3,
+                    },
+                    {
+                      id: asKeyframeId('1'),
+                      position: 20,
+                      connectedRight: false,
+                      handles: [0.5, 0.5, 0.5, 0.5],
+                      value: 6,
+                    },
+                  ],
+                },
               },
             },
           },
         },
-      },
+      })
+
+      const seq = sheet.publicApi.sequence
+
+      const objValues = iterateOver(prism(() => objPublicAPI.value))
+
+      expect(seq.position).toEqual(0)
+
+      expect(objValues.next().value).toMatchObject({
+        position: {x: 0, y: 3, z: 0},
+      })
+
+      seq.position = 5
+      expect(seq.position).toEqual(5)
+      expect(objValues.next().value).toMatchObject({
+        position: {x: 0, y: 3, z: 0},
+      })
+
+      seq.position = 11
+      expect(objValues.next().value).toMatchObject({
+        position: {x: 0, y: 3.29999747758308, z: 0},
+      })
+
+      seq.position = 15
+      expect(objValues.next().value).toMatchObject({
+        position: {x: 0, y: 4.5, z: 0},
+      })
+
+      seq.position = 22
+      expect(objValues.next().value).toMatchObject({
+        position: {x: 0, y: 6, z: 0},
+      })
+
+      objValues.return()
     })
-
-    const seq = sheet.publicApi.sequence
-
-    const objValues = iterateOver(prism(() => objPublicAPI.value))
-
-    expect(seq.position).toEqual(0)
-
-    expect(objValues.next().value).toMatchObject({
-      position: {x: 0, y: 3, z: 0},
-    })
-
-    seq.position = 5
-    expect(seq.position).toEqual(5)
-    expect(objValues.next().value).toMatchObject({
-      position: {x: 0, y: 3, z: 0},
-    })
-
-    seq.position = 11
-    expect(objValues.next().value).toMatchObject({
-      position: {x: 0, y: 3.29999747758308, z: 0},
-    })
-
-    seq.position = 15
-    expect(objValues.next().value).toMatchObject({
-      position: {x: 0, y: 4.5, z: 0},
-    })
-
-    seq.position = 22
-    expect(objValues.next().value).toMatchObject({
-      position: {x: 0, y: 6, z: 0},
-    })
-
-    objValues.return()
   })
 })

--- a/theatre/core/src/sheetObjects/SheetObject.ts
+++ b/theatre/core/src/sheetObjects/SheetObject.ts
@@ -23,14 +23,7 @@ import {Atom, getPointerParts, pointer, prism, val} from '@theatre/dataverse'
 import type SheetObjectTemplate from './SheetObjectTemplate'
 import TheatreSheetObject from './TheatreSheetObject'
 import type {Interpolator} from '@theatre/core/propTypes'
-import {getPropConfigByPath, valueInProp} from '@theatre/shared/propTypes/utils'
-
-// type Everything = {
-//   final: SerializableMap
-//   statics: SerializableMap
-//   defaults: SerializableMap
-//   sequenced: SerializableMap
-// }
+import {getPropConfigByPath} from '@theatre/shared/propTypes/utils'
 
 export default class SheetObject implements IdentityDerivationProvider {
   get type(): 'Theatre_SheetObject' {

--- a/theatre/core/src/sheetObjects/SheetObject.ts
+++ b/theatre/core/src/sheetObjects/SheetObject.ts
@@ -22,7 +22,7 @@ import type {
 import {Atom, getPointerParts, pointer, prism, val} from '@theatre/dataverse'
 import type SheetObjectTemplate from './SheetObjectTemplate'
 import TheatreSheetObject from './TheatreSheetObject'
-import type {Interpolator} from '@theatre/core/propTypes'
+import type {Interpolator, PropTypeConfig} from '@theatre/core/propTypes'
 import {getPropConfigByPath} from '@theatre/shared/propTypes/utils'
 
 export default class SheetObject implements IdentityDerivationProvider {
@@ -150,7 +150,7 @@ export default class SheetObject implements IdentityDerivationProvider {
             const propConfig = getPropConfigByPath(
               this.template.config,
               pathToProp,
-            )!
+            )! as Extract<PropTypeConfig, {interpolate: $IntentionalAny}>
 
             const deserialize = propConfig.deserialize
             const interpolate =

--- a/theatre/core/src/sheetObjects/SheetObject.ts
+++ b/theatre/core/src/sheetObjects/SheetObject.ts
@@ -159,8 +159,7 @@ export default class SheetObject implements IdentityDerivationProvider {
             const updateSequenceValueFromItsDerivation = () => {
               const triple = derivation.getValue()
 
-              if (!triple)
-                return valsAtom.setIn(pathToProp, propConfig!.default)
+              if (!triple) return valsAtom.setIn(pathToProp, undefined)
 
               const leftDeserialized = deserialize(triple.left)
 

--- a/theatre/core/src/sheetObjects/SheetObject.ts
+++ b/theatre/core/src/sheetObjects/SheetObject.ts
@@ -159,6 +159,7 @@ export default class SheetObject implements IdentityDerivationProvider {
               pathToProp,
             )!
 
+            const deserialize = propConfig.deserialize
             const interpolate =
               propConfig.interpolate! as Interpolator<$IntentionalAny>
 
@@ -168,12 +169,21 @@ export default class SheetObject implements IdentityDerivationProvider {
               if (!triple)
                 return valsAtom.setIn(pathToProp, propConfig!.default)
 
-              const left = valueInProp(triple.left, propConfig)
+              const leftDeserialized = deserialize(triple.left)
+
+              const left =
+                typeof leftDeserialized === 'undefined'
+                  ? propConfig.default
+                  : leftDeserialized
 
               if (triple.right === undefined)
                 return valsAtom.setIn(pathToProp, left)
 
-              const right = valueInProp(triple.right, propConfig)
+              const rightDeserialized = deserialize(triple.right)
+              const right =
+                typeof rightDeserialized === 'undefined'
+                  ? propConfig.default
+                  : rightDeserialized
 
               return valsAtom.setIn(
                 pathToProp,

--- a/theatre/core/src/sheetObjects/SheetObjectTemplate.ts
+++ b/theatre/core/src/sheetObjects/SheetObjectTemplate.ts
@@ -24,7 +24,10 @@ import getPropDefaultsOfSheetObject from './getPropDefaultsOfSheetObject'
 import SheetObject from './SheetObject'
 import logger from '@theatre/shared/logger'
 import type {PropTypeConfig_Compound} from '@theatre/core/propTypes'
-import {getPropConfigByPath} from '@theatre/shared/propTypes/utils'
+import {
+  getPropConfigByPath,
+  isPropConfSequencable,
+} from '@theatre/shared/propTypes/utils'
 import getOrderingOfPropTypeConfig from './getOrderingOfPropTypeConfig'
 
 export type IPropPathToTrackIdTree = {
@@ -140,7 +143,7 @@ export default class SheetObjectTemplate {
 
           const propConfig = getPropConfigByPath(this.config, pathToProp)
 
-          if (!propConfig || !propConfig.interpolate) continue
+          if (!propConfig || !isPropConfSequencable(propConfig)) continue
 
           arrayOfIds.push({pathToProp, trackId: trackId!})
         }

--- a/theatre/core/src/sheetObjects/SheetObjectTemplate.ts
+++ b/theatre/core/src/sheetObjects/SheetObjectTemplate.ts
@@ -140,8 +140,7 @@ export default class SheetObjectTemplate {
 
           const propConfig = getPropConfigByPath(this.config, pathToProp)
 
-          if (!propConfig || !propConfig?.sanitize || !propConfig.interpolate)
-            continue
+          if (!propConfig || !propConfig.interpolate) continue
 
           arrayOfIds.push({pathToProp, trackId: trackId!})
         }

--- a/theatre/core/src/sheetObjects/SheetObjectTemplate.ts
+++ b/theatre/core/src/sheetObjects/SheetObjectTemplate.ts
@@ -91,14 +91,16 @@ export default class SheetObjectTemplate {
             this.address.sheetId
           ]
 
-        const value =
+        const json =
           val(
             pointerToSheetState.staticOverrides.byObject[
               this.address.objectKey
             ],
           ) || {}
 
-        return value
+        const config = val(this._config.pointer)
+        const deserialized = config.deserialize(json) || {}
+        return deserialized
       }),
     )
   }

--- a/theatre/shared/src/propTypes/utils.ts
+++ b/theatre/shared/src/propTypes/utils.ts
@@ -1,6 +1,7 @@
 import type {
   IBasePropType,
   PropTypeConfig,
+  PropTypeConfig_AllNonCompounds,
   PropTypeConfig_Compound,
   PropTypeConfig_Enum,
 } from '@theatre/core/propTypes'
@@ -33,17 +34,18 @@ export function getPropConfigByPath(
 /**
  * @param value - An arbitrary value. May be matching the prop's type or not
  * @param propConfig - The configuration object for a prop
- * @returns value if it matches the prop's type (or if the prop doesn't have a sanitizer),
+ * @returns value if it matches the prop's type
  * otherwise returns the default value for the prop
  */
-export function valueInProp<PropValueType>(
+export function valueInProp<PropConfig extends PropTypeConfig_AllNonCompounds>(
   value: unknown,
-  propConfig: IBasePropType<PropValueType>,
-): PropValueType | unknown {
-  const sanitize = propConfig.sanitize
-  if (!sanitize) return value
+  propConfig: PropConfig,
+): PropConfig extends IBasePropType<$IntentionalAny, $IntentionalAny, infer T>
+  ? T
+  : never {
+  const deserialize = propConfig.deserialize
 
-  const sanitizedVal = sanitize(value)
+  const sanitizedVal = deserialize(value)
   if (typeof sanitizedVal === 'undefined') {
     return propConfig.default
   } else {

--- a/theatre/shared/src/propTypes/utils.ts
+++ b/theatre/shared/src/propTypes/utils.ts
@@ -52,3 +52,9 @@ export function valueInProp<PropConfig extends PropTypeConfig_AllNonCompounds>(
     return sanitizedVal
   }
 }
+
+export function isPropConfSequencable(
+  conf: PropTypeConfig,
+): conf is Extract<PropTypeConfig, {interpolate: any}> {
+  return Object.prototype.hasOwnProperty.call(conf, 'interpolate')
+}

--- a/theatre/shared/src/testUtils.ts
+++ b/theatre/shared/src/testUtils.ts
@@ -10,6 +10,15 @@ import coreTicker from '@theatre/core/coreTicker'
 import globals from './globals'
 /* eslint-enable no-restricted-syntax */
 
+const defaultProps = {
+  position: {
+    x: 0,
+    y: 0,
+    z: 0,
+  },
+  color: t.rgba(),
+}
+
 let lastProjectN = 0
 export async function setupTestSheet(sheetState: SheetState_Historic) {
   const studio = getStudio()!
@@ -31,13 +40,7 @@ export async function setupTestSheet(sheetState: SheetState_Historic) {
   ticker.tick()
   await project.ready
   const sheetPublicAPI = project.sheet('Sheet')
-  const objPublicAPI = sheetPublicAPI.object('obj', {
-    position: {
-      x: 0,
-      y: t.number(1),
-      z: t.number(2),
-    },
-  })
+  const objPublicAPI = sheetPublicAPI.object('obj', defaultProps)
 
   const obj = privateAPI(objPublicAPI)
 

--- a/theatre/shared/src/testUtils.ts
+++ b/theatre/shared/src/testUtils.ts
@@ -17,6 +17,11 @@ const defaultProps = {
     z: 0,
   },
   color: t.rgba(),
+  deeply: {
+    nested: {
+      checkbox: true,
+    },
+  },
 }
 
 let lastProjectN = 0

--- a/theatre/shared/src/utils/getDeep.ts
+++ b/theatre/shared/src/utils/getDeep.ts
@@ -3,7 +3,7 @@ import type {PathToProp} from './addresses'
 import type {SerializableValue} from './types'
 
 export default function getDeep(
-  v: SerializableValue,
+  v: SerializableValue | undefined,
   path: PathToProp,
 ): unknown {
   if (path.length === 0) return v

--- a/theatre/shared/src/utils/getDeep.ts
+++ b/theatre/shared/src/utils/getDeep.ts
@@ -3,7 +3,7 @@ import type {PathToProp} from './addresses'
 import type {SerializableValue} from './types'
 
 export default function getDeep(
-  v: SerializableValue | undefined,
+  v: SerializableValue,
   path: PathToProp,
 ): unknown {
   if (path.length === 0) return v

--- a/theatre/studio/src/StudioStore/StudioStore.ts
+++ b/theatre/studio/src/StudioStore/StudioStore.ts
@@ -20,7 +20,7 @@ import atomFromReduxStore from '@theatre/studio/utils/redux/atomFromReduxStore'
 import configureStore from '@theatre/studio/utils/redux/configureStore'
 import type {$FixMe, $IntentionalAny, VoidFn} from '@theatre/shared/utils/types'
 import type {Atom, Pointer} from '@theatre/dataverse'
-import {getPointerParts, val} from '@theatre/dataverse'
+import {getPointerParts} from '@theatre/dataverse'
 import type {Draft} from 'immer'
 import {createDraft, finishDraft} from 'immer'
 import get from 'lodash-es/get'
@@ -139,11 +139,9 @@ export default class StudioStore {
             if (isSheetObject(root)) {
               root.validateValue(pointer as Pointer<$FixMe>, _value)
 
-              const sequenceTracksTree = val(
-                root.template
-                  .getMapOfValidSequenceTracks_forStudio()
-                  .getValue(),
-              )
+              const sequenceTracksTree = root.template
+                .getMapOfValidSequenceTracks_forStudio()
+                .getValue()
 
               const propConfig = getPropConfigByPath(
                 root.template.config,
@@ -214,11 +212,9 @@ export default class StudioStore {
             ensureRunning()
             const {root, path} = getPointerParts(pointer as Pointer<$FixMe>)
             if (isSheetObject(root)) {
-              const sequenceTracksTree = val(
-                root.template
-                  .getMapOfValidSequenceTracks_forStudio()
-                  .getValue(),
-              )
+              const sequenceTracksTree = root.template
+                .getMapOfValidSequenceTracks_forStudio()
+                .getValue()
 
               const defaultValue = getDeep(
                 root.template.getDefaultValues().getValue(),

--- a/theatre/studio/src/StudioStore/StudioStore.ts
+++ b/theatre/studio/src/StudioStore/StudioStore.ts
@@ -13,26 +13,18 @@ import type {
 } from '@theatre/studio/store/types'
 import type {Deferred} from '@theatre/shared/utils/defer'
 import {defer} from '@theatre/shared/utils/defer'
-import forEachDeep from '@theatre/shared/utils/forEachDeep'
-import getDeep from '@theatre/shared/utils/getDeep'
-import type {SequenceTrackId} from '@theatre/shared/utils/ids'
 import atomFromReduxStore from '@theatre/studio/utils/redux/atomFromReduxStore'
 import configureStore from '@theatre/studio/utils/redux/configureStore'
-import type {$FixMe, $IntentionalAny, VoidFn} from '@theatre/shared/utils/types'
+import type {VoidFn} from '@theatre/shared/utils/types'
 import type {Atom, Pointer} from '@theatre/dataverse'
-import {getPointerParts} from '@theatre/dataverse'
 import type {Draft} from 'immer'
 import {createDraft, finishDraft} from 'immer'
-import get from 'lodash-es/get'
 import type {Store} from 'redux'
 import {persistStateOfStudio} from './persistStateOfStudio'
-import {isSheetObject} from '@theatre/shared/instanceTypes'
 import type {OnDiskState} from '@theatre/core/projects/store/storeTypes'
 import {generateDiskStateRevision} from './generateDiskStateRevision'
-import type {PropTypeConfig} from '@theatre/core/propTypes'
-import type {PathToProp} from '@theatre/shared/src/utils/addresses'
-import {getPropConfigByPath} from '@theatre/shared/propTypes/utils'
-import {cloneDeep} from 'lodash-es'
+
+import createTransactionPrivateApi from './createTransactionPrivateApi'
 
 export type Drafts = {
   historic: Draft<StudioHistoricState>
@@ -131,153 +123,13 @@ export default class StudioStore {
           }
         }
 
-        const api: ITransactionPrivateApi = {
-          set: (pointer, value) => {
-            ensureRunning()
-            const _value = cloneDeep(value)
-            const {root, path} = getPointerParts(pointer as Pointer<$FixMe>)
-            if (isSheetObject(root)) {
-              root.validateValue(pointer as Pointer<$FixMe>, _value)
-
-              const sequenceTracksTree = root.template
-                .getMapOfValidSequenceTracks_forStudio()
-                .getValue()
-
-              const propConfig = getPropConfigByPath(
-                root.template.config,
-                path,
-              ) as PropTypeConfig
-
-              const setStaticOrKeyframeProp = <T>(
-                value: T,
-                path: PathToProp,
-              ) => {
-                if (typeof value === 'undefined' || value === null) {
-                  return
-                }
-
-                const propAddress = {...root.address, pathToProp: path}
-
-                const trackId = get(sequenceTracksTree, path) as $FixMe as
-                  | SequenceTrackId
-                  | undefined
-                if (typeof trackId === 'string') {
-                  const propConfig = getPropConfigByPath(
-                    root.template.config,
-                    path,
-                  ) as PropTypeConfig | undefined
-                  // TODO: Make sure this causes no problems wrt decorated
-                  // or otherwise unserializable stuff that sanitize might return.
-                  // value needs to be serializable.
-                  if (propConfig?.sanitize) value = propConfig.sanitize(value)
-
-                  const seq = root.sheet.getSequence()
-                  seq.position = seq.closestGridPosition(seq.position)
-                  stateEditors.coreByProject.historic.sheetsById.sequence.setKeyframeAtPosition(
-                    {
-                      ...propAddress,
-                      trackId,
-                      position: seq.position,
-                      value: value as $FixMe,
-                      snappingFunction: seq.closestGridPosition,
-                    },
-                  )
-                } else if (propConfig !== undefined) {
-                  stateEditors.coreByProject.historic.sheetsById.staticOverrides.byObject.setValueOfPrimitiveProp(
-                    {...propAddress, value: value as $FixMe},
-                  )
-                }
-              }
-
-              // If we are dealing with a compound prop, we recurse through its
-              // nested properties.
-              if (propConfig.type === 'compound') {
-                forEachDeep(
-                  _value,
-                  (v, pathToProp) => {
-                    setStaticOrKeyframeProp(v, pathToProp)
-                  },
-                  getPointerParts(pointer as Pointer<$IntentionalAny>).path,
-                )
-              } else {
-                setStaticOrKeyframeProp(_value, path)
-              }
-            } else {
-              throw new Error(
-                'Only setting props of SheetObject-s is supported in a transaction so far',
-              )
-            }
-          },
-          unset: (pointer) => {
-            ensureRunning()
-            const {root, path} = getPointerParts(pointer as Pointer<$FixMe>)
-            if (isSheetObject(root)) {
-              const sequenceTracksTree = root.template
-                .getMapOfValidSequenceTracks_forStudio()
-                .getValue()
-
-              const defaultValue = getDeep(
-                root.template.getDefaultValues().getValue(),
-                path,
-              )
-
-              const propConfig = getPropConfigByPath(
-                root.template.config,
-                path,
-              ) as PropTypeConfig
-
-              const unsetStaticOrKeyframeProp = <T>(
-                value: T,
-                path: PathToProp,
-              ) => {
-                const propAddress = {...root.address, pathToProp: path}
-
-                const trackId = get(sequenceTracksTree, path) as $FixMe as
-                  | SequenceTrackId
-                  | undefined
-
-                if (typeof trackId === 'string') {
-                  stateEditors.coreByProject.historic.sheetsById.sequence.unsetKeyframeAtPosition(
-                    {
-                      ...propAddress,
-                      trackId,
-                      position: root.sheet.getSequence().positionSnappedToGrid,
-                    },
-                  )
-                } else if (propConfig !== undefined) {
-                  stateEditors.coreByProject.historic.sheetsById.staticOverrides.byObject.unsetValueOfPrimitiveProp(
-                    propAddress,
-                  )
-                }
-              }
-
-              if (propConfig.type === 'compound') {
-                forEachDeep(
-                  defaultValue,
-                  (v, pathToProp) => {
-                    unsetStaticOrKeyframeProp(v, pathToProp)
-                  },
-                  getPointerParts(pointer as Pointer<$IntentionalAny>).path,
-                )
-              } else {
-                unsetStaticOrKeyframeProp(defaultValue, path)
-              }
-            } else {
-              throw new Error(
-                'Only setting props of SheetObject-s is supported in a transaction so far',
-              )
-            }
-          },
-          get drafts() {
-            ensureRunning()
-            return drafts
-          },
-          get stateEditors() {
-            return stateEditors
-          },
-        }
-
         const stateEditors = setDrafts__onlyMeantToBeCalledByTransaction(drafts)
+
+        const api: ITransactionPrivateApi = createTransactionPrivateApi(
+          ensureRunning,
+          stateEditors,
+          drafts,
+        )
 
         try {
           fn(api)

--- a/theatre/studio/src/StudioStore/createTransactionPrivateApi.ts
+++ b/theatre/studio/src/StudioStore/createTransactionPrivateApi.ts
@@ -1,0 +1,226 @@
+import type {Pointer} from '@theatre/dataverse'
+import {isSheetObject} from '@theatre/shared/instanceTypes'
+import type {$FixMe, $IntentionalAny} from '@theatre/shared/utils/types'
+import get from 'lodash-es/get'
+import type {ITransactionPrivateApi} from './StudioStore'
+import forEachDeep from '@theatre/shared/utils/forEachDeep'
+import getDeep from '@theatre/shared/utils/getDeep'
+import type {SequenceTrackId} from '@theatre/shared/utils/ids'
+import {getPointerParts} from '@theatre/dataverse'
+import type {
+  PropTypeConfig,
+  PropTypeConfig_AllNonCompounds,
+  PropTypeConfig_Compound,
+} from '@theatre/core/propTypes'
+import type {PathToProp} from '@theatre/shared/src/utils/addresses'
+import {getPropConfigByPath} from '@theatre/shared/propTypes/utils'
+import {isPlainObject} from 'lodash-es'
+
+function cloneDeepSerializable<T>(v: T): T | undefined {
+  if (
+    typeof v === 'boolean' ||
+    typeof v === 'string' ||
+    typeof v === 'number'
+  ) {
+    return v
+  } else if (isPlainObject(v)) {
+    const cloned: $IntentionalAny = {}
+    let clonedAtLeastOneProp = false
+    for (const [key, val] of Object.entries(v)) {
+      const clonedVal = cloneDeepSerializable(val)
+      if (typeof clonedVal !== 'undefined') {
+        cloned[key] = val
+        clonedAtLeastOneProp = true
+      }
+    }
+    if (clonedAtLeastOneProp) {
+      return cloned
+    }
+  } else {
+    return undefined
+  }
+}
+
+function forEachDeepSimplePropOfCompoundProp(
+  propType: PropTypeConfig_Compound<$IntentionalAny>,
+  path: Array<string | number>,
+  callback: (
+    propType: PropTypeConfig_AllNonCompounds,
+    path: Array<string | number>,
+  ) => void,
+) {
+  for (const [key, subType] of Object.entries(propType.props)) {
+    if (subType.type === 'compound') {
+      forEachDeepSimplePropOfCompoundProp(subType, [...path, key], callback)
+    } else if (subType.type === 'enum') {
+      throw new Error(`Not yet implemented`)
+    } else {
+      callback(subType, [...path, key])
+    }
+  }
+}
+
+export default function createTransactionPrivateApi(
+  ensureRunning: () => void,
+  stateEditors: ITransactionPrivateApi['stateEditors'],
+  drafts: ITransactionPrivateApi['drafts'],
+): ITransactionPrivateApi {
+  return {
+    set: (pointer, value) => {
+      ensureRunning()
+      const _value = cloneDeepSerializable(value)
+
+      const {root, path} = getPointerParts(pointer as Pointer<$FixMe>)
+      if (isSheetObject(root)) {
+        const sequenceTracksTree = root.template
+          .getMapOfValidSequenceTracks_forStudio()
+          .getValue()
+
+        const propConfig = getPropConfigByPath(root.template.config, path)
+
+        if (!propConfig) {
+          // TODO: should we just throw here?
+          console.error(
+            `Object ${
+              root.address.objectKey
+            } does not have a prop at ${JSON.stringify(path)}`,
+          )
+          return
+        }
+
+        // if (isPropConfigComposite(propConfig)) {
+        //   propConfig.validatePartial(_value)
+        // } else {
+        //   propConfig.validate(_value)
+        // }
+
+        const setStaticOrKeyframeProp = <T>(
+          value: T,
+          propConfig: PropTypeConfig_AllNonCompounds,
+          path: PathToProp,
+        ) => {
+          if (typeof value === 'undefined' || value === null) {
+            return
+          }
+
+          const propAddress = {...root.address, pathToProp: path}
+
+          const trackId = get(sequenceTracksTree, path) as $FixMe as
+            | SequenceTrackId
+            | undefined
+
+          if (typeof trackId === 'string') {
+            // TODO: Make sure this causes no problems wrt decorated
+            // or otherwise unserializable stuff that sanitize might return.
+            // value needs to be serializable.
+            if (propConfig?.sanitize) value = propConfig.sanitize(value)
+
+            const seq = root.sheet.getSequence()
+            seq.position = seq.closestGridPosition(seq.position)
+            stateEditors.coreByProject.historic.sheetsById.sequence.setKeyframeAtPosition(
+              {
+                ...propAddress,
+                trackId,
+                position: seq.position,
+                value: value as $FixMe,
+                snappingFunction: seq.closestGridPosition,
+              },
+            )
+          } else if (propConfig !== undefined) {
+            stateEditors.coreByProject.historic.sheetsById.staticOverrides.byObject.setValueOfPrimitiveProp(
+              {...propAddress, value: value as $FixMe},
+            )
+          }
+        }
+
+        if (propConfig.type === 'compound') {
+          // If we are dealing with a compound prop, we recurse through its
+          // nested properties.
+          forEachDeepSimplePropOfCompoundProp(
+            propConfig,
+
+            getPointerParts(pointer as Pointer<$IntentionalAny>).path,
+            (primitivePropConfig, pathToProp) => {
+              const v = getDeep(_value, pathToProp)
+              if (typeof v !== 'undefined') {
+                setStaticOrKeyframeProp(v, primitivePropConfig, pathToProp)
+              }
+            },
+          )
+        } else if (propConfig.type === 'enum') {
+          throw new Error(`Enums aren't implemented yet`)
+        } else {
+          setStaticOrKeyframeProp(_value, propConfig, path)
+        }
+      } else {
+        throw new Error(
+          'Only setting props of SheetObject-s is supported in a transaction so far',
+        )
+      }
+    },
+    unset: (pointer) => {
+      ensureRunning()
+      const {root, path} = getPointerParts(pointer as Pointer<$FixMe>)
+      if (isSheetObject(root)) {
+        const sequenceTracksTree = root.template
+          .getMapOfValidSequenceTracks_forStudio()
+          .getValue()
+
+        const defaultValue = getDeep(
+          root.template.getDefaultValues().getValue(),
+          path,
+        )
+
+        const propConfig = getPropConfigByPath(
+          root.template.config,
+          path,
+        ) as PropTypeConfig
+
+        const unsetStaticOrKeyframeProp = <T>(value: T, path: PathToProp) => {
+          const propAddress = {...root.address, pathToProp: path}
+
+          const trackId = get(sequenceTracksTree, path) as $FixMe as
+            | SequenceTrackId
+            | undefined
+
+          if (typeof trackId === 'string') {
+            stateEditors.coreByProject.historic.sheetsById.sequence.unsetKeyframeAtPosition(
+              {
+                ...propAddress,
+                trackId,
+                position: root.sheet.getSequence().positionSnappedToGrid,
+              },
+            )
+          } else if (propConfig !== undefined) {
+            stateEditors.coreByProject.historic.sheetsById.staticOverrides.byObject.unsetValueOfPrimitiveProp(
+              propAddress,
+            )
+          }
+        }
+
+        if (propConfig.type === 'compound') {
+          forEachDeep(
+            defaultValue,
+            (v, pathToProp) => {
+              unsetStaticOrKeyframeProp(v, pathToProp)
+            },
+            getPointerParts(pointer as Pointer<$IntentionalAny>).path,
+          )
+        } else {
+          unsetStaticOrKeyframeProp(defaultValue, path)
+        }
+      } else {
+        throw new Error(
+          'Only setting props of SheetObject-s is supported in a transaction so far',
+        )
+      }
+    },
+    get drafts() {
+      ensureRunning()
+      return drafts
+    },
+    get stateEditors() {
+      return stateEditors
+    },
+  }
+}

--- a/theatre/studio/src/StudioStore/createTransactionPrivateApi.ts
+++ b/theatre/studio/src/StudioStore/createTransactionPrivateApi.ts
@@ -135,14 +135,21 @@ export default function createTransactionPrivateApi(
         }
 
         if (propConfig.type === 'compound') {
+          const pathToTopPointer = getPointerParts(
+            pointer as $IntentionalAny,
+          ).path
+
+          const lengthOfTopPointer = pathToTopPointer.length
           // If we are dealing with a compound prop, we recurse through its
           // nested properties.
           forEachDeepSimplePropOfCompoundProp(
             propConfig,
-
-            getPointerParts(pointer as Pointer<$IntentionalAny>).path,
+            pathToTopPointer,
             (primitivePropConfig, pathToProp) => {
-              const v = getDeep(_value, pathToProp)
+              const pathToPropInProvidedValue =
+                pathToProp.slice(lengthOfTopPointer)
+
+              const v = getDeep(_value, pathToPropInProvidedValue)
               if (typeof v !== 'undefined') {
                 setStaticOrKeyframeProp(v, primitivePropConfig, pathToProp)
               }

--- a/theatre/studio/src/StudioStore/createTransactionPrivateApi.ts
+++ b/theatre/studio/src/StudioStore/createTransactionPrivateApi.ts
@@ -80,13 +80,11 @@ export default function createTransactionPrivateApi(
         const propConfig = getPropConfigByPath(root.template.config, path)
 
         if (!propConfig) {
-          // TODO: should we just throw here?
-          console.error(
+          throw new Error(
             `Object ${
               root.address.objectKey
             } does not have a prop at ${JSON.stringify(path)}`,
           )
-          return
         }
 
         // if (isPropConfigComposite(propConfig)) {

--- a/theatre/studio/src/StudioStore/createTransactionPrivateApi.ts
+++ b/theatre/studio/src/StudioStore/createTransactionPrivateApi.ts
@@ -15,6 +15,7 @@ import type {
 import type {PathToProp} from '@theatre/shared/src/utils/addresses'
 import {getPropConfigByPath} from '@theatre/shared/propTypes/utils'
 import {isPlainObject} from 'lodash-es'
+import userReadableTypeOfValue from '@theatre/shared/utils/userReadableTypeOfValue'
 
 function cloneDeepSerializable<T>(v: T): T | undefined {
   if (
@@ -88,8 +89,9 @@ export default function createTransactionPrivateApi(
         }
 
         // if (isPropConfigComposite(propConfig)) {
-        //   propConfig.validatePartial(_value)
+        //   propConfig.validate(_value)
         // } else {
+
         //   propConfig.validate(_value)
         // }
 
@@ -105,7 +107,15 @@ export default function createTransactionPrivateApi(
           const deserialized = cloneDeepSerializable(
             propConfig.deserialize(value),
           )
-          if (typeof deserialized === 'undefined') return
+          if (typeof deserialized === 'undefined') {
+            throw new Error(
+              `Invalid value ${userReadableTypeOfValue(
+                value,
+              )} for object.props${path
+                .map((key) => `[${JSON.stringify(key)}]`)
+                .join('')} is invalid`,
+            )
+          }
 
           const propAddress = {...root.address, pathToProp: path}
 
@@ -150,6 +160,12 @@ export default function createTransactionPrivateApi(
               const v = getDeep(_value, pathToPropInProvidedValue)
               if (typeof v !== 'undefined') {
                 setStaticOrKeyframeProp(v, primitivePropConfig, pathToProp)
+              } else {
+                throw new Error(
+                  `Property object.props${pathToProp
+                    .map((key) => `[${JSON.stringify(key)}]`)
+                    .join('')} is required but not provided`,
+                )
               }
             },
           )

--- a/theatre/studio/src/panels/DetailPanel/propEditors/utils/useEditingToolsForPrimitiveProp.tsx
+++ b/theatre/studio/src/panels/DetailPanel/propEditors/utils/useEditingToolsForPrimitiveProp.tsx
@@ -13,6 +13,7 @@ import React from 'react'
 import DefaultOrStaticValueIndicator from './DefaultValueIndicator'
 import NextPrevKeyframeCursors from './NextPrevKeyframeCursors'
 import type {PropTypeConfig} from '@theatre/core/propTypes'
+import {isPropConfSequencable} from '@theatre/shared/propTypes/utils'
 
 interface CommonStuff<T> {
   value: T
@@ -309,7 +310,3 @@ type Shade =
   | 'Sequenced_OnKeyframe_BeingScrubbed'
   | 'Sequenced_BeingInterpolated'
   | 'Sequened_NotBeingInterpolated'
-
-function isPropConfSequencable(conf: PropTypeConfig): boolean {
-  return conf.type === 'number' || (!!conf.sanitize && !!conf.interpolate)
-}

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/LengthIndicator/LengthIndicator.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/LengthIndicator/LengthIndicator.tsx
@@ -132,7 +132,7 @@ type IProps = {
 
 const LengthIndicator: React.FC<IProps> = ({layoutP}) => {
   const [nodeRef, node] = useRefAndState<HTMLDivElement | null>(null)
-  const [isDraggingD] = useDragBulge(node, {layoutP})
+  const [isDragging] = useDragBulge(node, {layoutP})
   const [popoverNode, openPopover, closePopover, isPopoverOpen] = usePopover(
     {},
     () => {
@@ -177,7 +177,7 @@ const LengthIndicator: React.FC<IProps> = ({layoutP}) => {
             height: height + 'px',
             transform: `translateX(${translateX === 0 ? -1000 : translateX}px)`,
           }}
-          className={val(isDraggingD) ? 'dragging' : ''}
+          className={isDragging ? 'dragging' : ''}
         >
           <ThumbContainer>
             <Tumb
@@ -206,10 +206,13 @@ const LengthIndicator: React.FC<IProps> = ({layoutP}) => {
         />
       </>
     )
-  }, [layoutP, nodeRef, isDraggingD, popoverNode])
+  }, [layoutP, nodeRef, isDragging, popoverNode])
 }
 
-function useDragBulge(node: HTMLDivElement | null, props: IProps) {
+function useDragBulge(
+  node: HTMLDivElement | null,
+  props: IProps,
+): [isDragging: boolean] {
   const propsRef = useRef(props)
   propsRef.current = props
   const [isDragging, setIsDragging] = useState(false)

--- a/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/BasicKeyframedTrack/KeyframeEditor/KeyframeEditor.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/BasicKeyframedTrack/KeyframeEditor/KeyframeEditor.tsx
@@ -15,7 +15,7 @@ import CurveHandle from './CurveHandle'
 import GraphEditorDotScalar from './GraphEditorDotScalar'
 import GraphEditorDotNonScalar from './GraphEditorDotNonScalar'
 import GraphEditorNonScalarDash from './GraphEditorNonScalarDash'
-import type {PropTypeConfig} from '@theatre/core/propTypes'
+import type {PropTypeConfig_AllNonCompounds} from '@theatre/core/propTypes'
 
 const Container = styled.g`
   /* position: absolute; */
@@ -33,7 +33,7 @@ const KeyframeEditor: React.FC<{
   extremumSpace: ExtremumSpace
   isScalar: boolean
   color: keyof typeof graphEditorColors
-  propConfig: PropTypeConfig
+  propConfig: PropTypeConfig_AllNonCompounds
 }> = (props) => {
   const {index, trackData, isScalar} = props
   const cur = trackData.keyframes[index]

--- a/theatre/studio/src/panels/SequenceEditorPanel/layout/tree.ts
+++ b/theatre/studio/src/panels/SequenceEditorPanel/layout/tree.ts
@@ -1,7 +1,7 @@
 import type {} from '@theatre/core/projects/store/types/SheetState_Historic'
 import type {
   PropTypeConfig,
-  PropTypeConfig_AllPrimitives,
+  PropTypeConfig_AllNonCompounds,
   PropTypeConfig_Compound,
 } from '@theatre/core/propTypes'
 import type SheetObject from '@theatre/core/sheetObjects/SheetObject'
@@ -53,7 +53,7 @@ export type SequenceEditorTree_PrimitiveProp =
     sheetObject: SheetObject
     pathToProp: PathToProp
     trackId: SequenceTrackId
-    propConf: PropTypeConfig_AllPrimitives
+    propConf: PropTypeConfig_AllNonCompounds
   }
 
 export type SequenceEditorTree_AllRowTypes =
@@ -231,7 +231,7 @@ export const calculateSequenceEditorTree = (
     sheetObject: SheetObject,
     trackId: SequenceTrackId,
     pathToProp: PathToProp,
-    propConf: PropTypeConfig_AllPrimitives,
+    propConf: PropTypeConfig_AllNonCompounds,
     arrayOfChildren: Array<
       SequenceEditorTree_PrimitiveProp | SequenceEditorTree_PropWithChildren
     >,


### PR DESCRIPTION
TODO:

- [x] Allow non-compound types, including the color type, to be sequenced
- [x] Find a better name for non-compound types
- [x] Allow partially setting the value of 
- [x] Implement partial validation of prop type values
- [x] Enforce serializability in all prop types
- [x] Unify "deserialize" and "sanitize"
- [x] ~~Make the `object.props`' pointer disallow pointing to sub-props of simple types.~~ Edit _pointing_ to sub-props of simple types should be fine. But setting them individually is a runtime error. It would have been nice if we also disallowed this in types, but the pointer types are already fairly complex, and I don't think putting even more type logic in there is worth the very limited payoff.
- [x] Write tests
- [x] Sanitize static overrides
- [x] Sanitize sequenced overrides
- [x] Fix the static<->sequenced flow
- [x] Tests for type conformance when setting overrides