### PR TITLE
Bump 'react-shadow' to v19.0.3

### DIFF
--- a/packages/r3f/package.json
+++ b/packages/r3f/package.json
@@ -48,7 +48,7 @@
     "polished": "^4.1.3",
     "react-icons": "^4.2.0",
     "react-merge-refs": "^1.1.0",
-    "react-shadow": "^19.0.2",
+    "react-shadow": "^19.0.3",
     "react-use-measure": "^2.0.4",
     "reakit": "^1.3.8",
     "styled-components": "^5.3.0",

--- a/theatre/package.json
+++ b/theatre/package.json
@@ -74,7 +74,7 @@
     "react-icons": "^4.2.0",
     "react-is": "^17.0.2",
     "react-merge-refs": "^1.1.0",
-    "react-shadow": "^19.0.2",
+    "react-shadow": "^19.0.3",
     "react-use": "^17.2.4",
     "react-use-gesture": "^9.1.3",
     "reakit": "^1.3.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6597,7 +6597,7 @@ __metadata:
     polished: ^4.1.3
     react-icons: ^4.2.0
     react-merge-refs: ^1.1.0
-    react-shadow: ^19.0.2
+    react-shadow: ^19.0.3
     react-use-measure: ^2.0.4
     reakit: ^1.3.8
     styled-components: ^5.3.0
@@ -24533,9 +24533,9 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-shadow@npm:^19.0.2":
-  version: 19.0.2
-  resolution: "react-shadow@npm:19.0.2"
+"react-shadow@npm:^19.0.3":
+  version: 19.0.3
+  resolution: "react-shadow@npm:19.0.3"
   dependencies:
     humps: ^2.0.1
     react-use: ^15.3.3
@@ -24543,7 +24543,7 @@ fsevents@^1.2.7:
     prop-types: ^15.0.0
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.0.0 || ^17.0.0
-  checksum: 0ec53be78748eb8a8f53d09795abdd515eae9cfb297e46c2997a70a3865a7f5f1ad634cc679e79a1f1ab82da457ce9508a63e5078657f1354a0d75fa94c31fcf
+  checksum: eb789ac10a85bf872406493189916a60aacec07a4eaaaf5b15d7fc8f7de3bfb9b1531f17dd899c6270700b6e964c828355798bc06e688c71a372272cbd8a5729
   languageName: node
   linkType: hard
 
@@ -27698,7 +27698,7 @@ fsevents@^1.2.7:
     react-icons: ^4.2.0
     react-is: ^17.0.2
     react-merge-refs: ^1.1.0
-    react-shadow: ^19.0.2
+    react-shadow: ^19.0.3
     react-use: ^17.2.4
     react-use-gesture: ^9.1.3
     reakit: ^1.3.8


### PR DESCRIPTION
Picking up a recent fix from https://github.com/Wildhoney/ReactShadow/pull/121.

Without this, we needed to include a hack (below) in our code, so this just enables a bit of cleanup.

```html
window.global = window;
```