### PR TITLE
Fix typo?

### DIFF
--- a/packages/dataverse/docs/GET_STARTED.md
+++ b/packages/dataverse/docs/GET_STARTED.md
@@ -68,7 +68,7 @@ console.log(variableB.get()) // prints 'some value' in the console
 ```
 
 > As you can see there's a naming convention here for boxes (`variableB`),
-> pointers (`variableP`), derivations (`variableP`), etc...
+> pointers (`variableP`), derivations (`variableD`), etc...
 
 Now we can change the value:
 


### PR DESCRIPTION
On dataverse naming convention docs. It says that derivations have the convention `variableP` but I think it should say `variableD`?