### PR TITLE
Make editable schema-based

### DIFF
--- a/packages/playground/src/shared/r3f-rocket/App.tsx
+++ b/packages/playground/src/shared/r3f-rocket/App.tsx
@@ -1,5 +1,5 @@
 import {editable as e, RefreshSnapshot, SheetProvider} from '@theatre/r3f'
-import {OrbitControls, Stars} from '@react-three/drei'
+import { Stars} from '@react-three/drei'
 import {getProject} from '@theatre/core'
 import React, {Suspense, useState} from 'react'
 import {Canvas} from '@react-three/fiber'
@@ -85,12 +85,6 @@ function App() {
             <RefreshSnapshot />
             <Model url={sceneGLB} />
           </Suspense>
-          <OrbitControls
-            enablePan={false}
-            enableZoom={true}
-            maxPolarAngle={Math.PI / 2}
-            minPolarAngle={Math.PI / 2}
-          />
           <Stars radius={500} depth={50} count={1000} factor={10} />
         </SheetProvider>
       </Canvas>

--- a/packages/r3f/src/components/EditableProxy.tsx
+++ b/packages/r3f/src/components/EditableProxy.tsx
@@ -8,8 +8,9 @@ import studio from '@theatre/studio'
 import {useSelected} from './useSelected'
 import {useVal} from '@theatre/react'
 import {getEditorSheetObject} from './editorStuff'
+import type {IconID} from '../icons';
 import icons from '../icons'
-import type {Helper, IconID} from '../editableFactoryConfigUtils'
+import type {Helper} from '../editableFactoryConfigUtils'
 import {useFrame, useThree} from '@react-three/fiber'
 
 export interface EditableProxyProps {

--- a/packages/r3f/src/components/EditableProxy.tsx
+++ b/packages/r3f/src/components/EditableProxy.tsx
@@ -8,10 +8,10 @@ import studio from '@theatre/studio'
 import {useSelected} from './useSelected'
 import {useVal} from '@theatre/react'
 import {getEditorSheetObject} from './editorStuff'
-import type {IconID} from '../icons';
+import type {IconID} from '../icons'
 import icons from '../icons'
 import type {Helper} from '../editableFactoryConfigUtils'
-import {useFrame, useThree} from '@react-three/fiber'
+import {invalidate, useFrame, useThree} from '@react-three/fiber'
 
 export interface EditableProxyProps {
   editableName: string
@@ -63,10 +63,12 @@ const EditableProxy: VFC<EditableProxyProps> = ({
   useEffect(() => {
     if (selected === uniqueName || hovered) {
       scene.add(helper)
+      invalidate()
     }
 
     return () => {
       scene.remove(helper)
+      invalidate()
     }
   }, [selected, hovered, helper, scene])
   useFrame(() => {

--- a/packages/r3f/src/components/editable.tsx
+++ b/packages/r3f/src/components/editable.tsx
@@ -1,222 +1,178 @@
 import type {ComponentProps, ComponentType, RefAttributes} from 'react'
 import React, {forwardRef, useLayoutEffect, useRef, useState} from 'react'
-import type {
-  DirectionalLight,
-  Group,
-  Mesh,
-  OrthographicCamera,
-  PerspectiveCamera,
-  PointLight,
-  SpotLight,
-} from 'three'
-import {Vector3} from 'three'
-import type {EditableType} from '../store'
-import {allRegisteredObjects} from '../store'
-import {baseSheetObjectType} from '../store'
-import {useEditorStore} from '../store'
+import {allRegisteredObjects, useEditorStore} from '../store'
 import mergeRefs from 'react-merge-refs'
 import type {$FixMe} from '@theatre/shared/utils/types'
 import type {ISheetObject} from '@theatre/core'
 import useInvalidate from './useInvalidate'
 import {useCurrentSheet} from '../SheetProvider'
+import defaultEditableFactoryConfig from '../defaultEditableFactoryConfig'
+import type {EditableFactoryConfig} from '../editableFactoryConfigUtils'
 
-interface Elements {
-  group: Group
-  mesh: Mesh
-  spotLight: SpotLight
-  directionalLight: DirectionalLight
-  perspectiveCamera: PerspectiveCamera
-  orthographicCamera: OrthographicCamera
-  pointLight: PointLight
-}
-
-const editable = <
-  T extends ComponentType<any> | EditableType | 'primitive',
-  U extends T extends EditableType ? T : EditableType,
->(
-  Component: T,
-  type: T extends 'primitive' ? null : U,
+const createEditable = <Keys extends keyof JSX.IntrinsicElements>(
+  config: EditableFactoryConfig,
 ) => {
-  type Props = Omit<ComponentProps<T>, 'visible'> & {
-    uniqueName: string
-    visible?: boolean | 'editor'
-    additionalProps?: $FixMe
-    objRef?: $FixMe
-  } & (T extends 'primitive'
-      ? {
-          editableType: U
-        }
-      : {}) &
-    RefAttributes<Elements[U]>
+  const editable = <
+    T extends ComponentType<any> | Keys | 'primitive',
+    U extends T extends Keys ? T : Keys,
+  >(
+    Component: T,
+    type: T extends 'primitive' ? null : U,
+  ) => {
+    type Props = Omit<ComponentProps<T>, 'visible'> & {
+      uniqueName: string
+      visible?: boolean | 'editor'
+      additionalProps?: $FixMe
+      objRef?: $FixMe
+    } & (T extends 'primitive'
+        ? {
+            editableType: U
+          }
+        : {}) &
+      RefAttributes<JSX.IntrinsicElements[U]>
 
-  return forwardRef(
-    (
-      {
-        uniqueName,
-        visible,
-        editableType,
-        additionalProps,
-        objRef,
-        ...props
-      }: Props,
-      ref,
-    ) => {
-      const objectRef = useRef<Elements[U]>()
+    return forwardRef(
+      (
+        {
+          uniqueName,
+          visible,
+          editableType,
+          additionalProps,
+          objRef,
+          ...props
+        }: Props,
+        ref,
+      ) => {
+        const actualType = type ?? editableType
 
-      const sheet = useCurrentSheet()
+        const objectRef = useRef<JSX.IntrinsicElements[U]>()
 
-      const [sheetObject, setSheetObject] = useState<
-        undefined | ISheetObject<$FixMe>
-      >(undefined)
+        const sheet = useCurrentSheet()
 
-      const invalidate = useInvalidate()
+        const [sheetObject, setSheetObject] = useState<
+          undefined | ISheetObject<$FixMe>
+        >(undefined)
 
-      useLayoutEffect(() => {
-        if (!sheet) return
-        const sheetObject = sheet.object(uniqueName, {
-          ...baseSheetObjectType,
-          ...additionalProps,
-        })
-        allRegisteredObjects.add(sheetObject)
-        setSheetObject(sheetObject)
+        const invalidate = useInvalidate()
 
-        if (objRef) objRef!.current = sheetObject
+        useLayoutEffect(() => {
+          if (!sheet) return
+          const sheetObject = sheet.object(
+            uniqueName,
+            Object.assign(
+              {
+                ...additionalProps,
+              },
+              // @ts-ignore
+              ...Object.values(config[actualType].props).map(
+                // @ts-ignore
+                (value) => value.type,
+              ),
+            ),
+          )
+          allRegisteredObjects.add(sheetObject)
+          setSheetObject(sheetObject)
 
-        useEditorStore
-          .getState()
-          .setSheetObject(uniqueName, sheetObject as $FixMe)
-      }, [sheet, uniqueName])
+          if (objRef) objRef!.current = sheetObject
 
-      const transformDeps: string[] = []
+          useEditorStore.getState().addEditable(uniqueName, {
+            type: actualType,
+            sheetObject,
+            visibleOnlyInEditor: visible === 'editor',
+            // @ts-ignore
+            objectConfig: config[actualType],
+          })
+        }, [sheet, uniqueName])
 
-      ;['x', 'y', 'z'].forEach((axis) => {
-        transformDeps.push(
-          props[`position-${axis}` as any],
-          props[`rotation-${axis}` as any],
-          props[`scale-${axis}` as any],
+        // store initial values of props
+        useLayoutEffect(() => {
+          if (!sheetObject) return
+          sheetObject!.initialValue = Object.fromEntries(
+            // @ts-ignore
+            Object.entries(config[actualType].props).map(
+              // @ts-ignore
+              ([key, value]) => [key, value.parse(props)],
+            ),
+          )
+        }, [
+          uniqueName,
+          sheetObject,
+          // @ts-ignore
+          ...Object.keys(config[actualType].props).map(
+            // @ts-ignore
+            (key) => props[key],
+          ),
+        ])
+
+        // subscribe to prop changes from theatre
+        useLayoutEffect(() => {
+          if (!sheetObject) return
+
+          const object = objectRef.current!
+
+          const setFromTheatre = (newValues: any) => {
+            // @ts-ignore
+            Object.entries(config[actualType].props).forEach(
+              // @ts-ignore
+              ([key, value]) => value.apply(newValues[key], object),
+            )
+            // @ts-ignore
+            config[actualType].updateObject?.(object)
+            invalidate()
+          }
+
+          setFromTheatre(sheetObject.value)
+
+          const untap = sheetObject.onValuesChange(setFromTheatre)
+
+          return () => {
+            untap()
+          }
+        }, [sheetObject])
+
+        return (
+          // @ts-ignore
+          <Component
+            ref={mergeRefs([objectRef, ref])}
+            {...props}
+            visible={visible !== 'editor' && visible}
+            userData={{
+              __editable: true,
+              __editableName: uniqueName,
+            }}
+          />
         )
-      })
+      },
+    )
+  }
 
-      // store initial values of props
-      useLayoutEffect(() => {
-        if (!sheetObject) return
-        // calculate initial properties before adding the editable
-        const position: Vector3 = props.position
-          ? Array.isArray(props.position)
-            ? new Vector3(...(props.position as any))
-            : props.position
-          : new Vector3()
-        const rotation: Vector3 = props.rotation
-          ? Array.isArray(props.rotation)
-            ? new Vector3(...(props.rotation as any))
-            : props.rotation
-          : new Vector3()
-        const scale: Vector3 = props.scale
-          ? Array.isArray(props.scale)
-            ? new Vector3(...(props.scale as any))
-            : props.scale
-          : new Vector3(1, 1, 1)
-
-        ;['x', 'y', 'z'].forEach((axis, index) => {
-          if (props[`position-${axis}` as any])
-            position.setComponent(index, props[`position-${axis}` as any])
-          if (props[`rotation-${axis}` as any])
-            rotation.setComponent(index, props[`rotation-${axis}` as any])
-          if (props[`scale-${axis}` as any])
-            scale.setComponent(index, props[`scale-${axis}` as any])
-        })
-
-        const initial = {
-          position: {
-            x: position.x,
-            y: position.y,
-            z: position.z,
-          },
-          rotation: {
-            x: rotation.x,
-            y: rotation.y,
-            z: rotation.z,
-          },
-          scale: {
-            x: scale.x,
-            y: scale.y,
-            z: scale.z,
-          },
-        }
-        sheetObject!.initialValue = initial
-      }, [
-        uniqueName,
-        sheetObject,
-        props.position,
-        props.rotation,
-        props.scale,
-
-        ...transformDeps,
-      ])
-
-      // subscribe to prop changes from theatre
-      useLayoutEffect(() => {
-        if (!sheetObject) return
-
-        const object = objectRef.current!
-
-        const setFromTheatre = (newValues: any) => {
-          object.position.set(
-            newValues.position.x,
-            newValues.position.y,
-            newValues.position.z,
-          )
-          object.rotation.set(
-            newValues.rotation.x,
-            newValues.rotation.y,
-            newValues.rotation.z,
-          )
-          object.scale.set(
-            newValues.scale.x,
-            newValues.scale.y,
-            newValues.scale.z,
-          )
-          invalidate()
-        }
-
-        setFromTheatre(sheetObject.value)
-
-        const untap = sheetObject.onValuesChange(setFromTheatre)
-
-        return () => {
-          untap()
-        }
-      }, [sheetObject])
-
-      return (
+  const extensions = {
+    ...Object.fromEntries(
+      Object.keys(config).map((key) => [
+        key,
         // @ts-ignore
-        <Component
-          ref={mergeRefs([objectRef, ref])}
-          {...props}
-          visible={visible !== 'editor' && visible}
-          userData={{
-            __editable: true,
-            __editableName: uniqueName,
-            __editableType: type ?? editableType,
-            __visibleOnlyInEditor: visible === 'editor',
-          }}
-        />
-      )
-    },
-  )
+        editable(key, key),
+      ]),
+    ),
+    primitive: editable('primitive', null),
+  } as unknown as {
+    [Property in Keys]: React.ForwardRefExoticComponent<
+      React.PropsWithoutRef<
+        Omit<JSX.IntrinsicElements[Property], 'visible'> & {
+          uniqueName: string
+          visible?: boolean | 'editor'
+          additionalProps?: $FixMe
+          objRef?: $FixMe
+        } & React.RefAttributes<JSX.IntrinsicElements[Property]>
+      >
+    >
+  }
+
+  return Object.assign(editable, extensions)
 }
 
-const createEditable = <T extends EditableType>(type: T) =>
-  // @ts-ignore
-  editable(type, type)
-
-editable.primitive = editable('primitive', null)
-editable.group = createEditable('group')
-editable.mesh = createEditable('mesh')
-editable.spotLight = createEditable('spotLight')
-editable.directionalLight = createEditable('directionalLight')
-editable.pointLight = createEditable('pointLight')
-editable.perspectiveCamera = createEditable('perspectiveCamera')
-editable.orthographicCamera = createEditable('orthographicCamera')
+const editable = createEditable<keyof typeof defaultEditableFactoryConfig>(
+  defaultEditableFactoryConfig,
+)
 
 export default editable

--- a/packages/r3f/src/defaultEditableFactoryConfig.ts
+++ b/packages/r3f/src/defaultEditableFactoryConfig.ts
@@ -1,0 +1,103 @@
+import type {
+  EditableFactoryConfig} from './editableFactoryConfigUtils';
+import {
+  createNumberPropConfig,
+  createVector,
+  createVectorPropConfig,
+  extendObjectProps,
+} from './editableFactoryConfigUtils'
+import type {
+  DirectionalLight,
+  Object3D,
+  OrthographicCamera,
+  PerspectiveCamera,
+  PointLight,
+  SpotLight} from 'three';
+import {
+  BoxHelper,
+  CameraHelper,
+  DirectionalLightHelper,
+  PointLightHelper,
+  SpotLightHelper,
+} from 'three'
+
+const baseObjectConfig = {
+  props: {
+    position: createVectorPropConfig('position'),
+    rotation: createVectorPropConfig('rotation'),
+    scale: createVectorPropConfig('scale', createVector([1, 1, 1])),
+  },
+  useTransformControls: true,
+}
+
+const baseLightConfig = {
+  ...extendObjectProps(baseObjectConfig, {
+    intensity: createNumberPropConfig('intensity', 1),
+    distance: createNumberPropConfig('distance'),
+    decay: createNumberPropConfig('decay'),
+  }),
+  dimensionless: true,
+}
+
+const baseCameraConfig = {
+  ...extendObjectProps(baseObjectConfig, {
+    near: createNumberPropConfig('near', 0.1),
+    far: createNumberPropConfig('far', 2000),
+  }),
+  updateObject: (camera: PerspectiveCamera | OrthographicCamera) => {
+    camera.updateProjectionMatrix()
+  },
+  icon: 'camera' as const,
+  dimensionless: true,
+  createHelper: (camera: PerspectiveCamera) => new CameraHelper(camera),
+}
+
+const selectionColor = '#40AAA4'
+
+const defaultEditableFactoryConfig = {
+  group: {
+    ...baseObjectConfig,
+    icon: 'collection' as const,
+    createHelper: (object: Object3D) => new BoxHelper(object, selectionColor),
+  },
+  mesh: {
+    ...baseObjectConfig,
+    icon: 'cube' as const,
+    createHelper: (object: Object3D) => new BoxHelper(object, selectionColor),
+  },
+  spotLight: {
+    ...extendObjectProps(baseLightConfig, {
+      angle: createNumberPropConfig('angle'),
+      penumbra: createNumberPropConfig('penumbra'),
+    }),
+    icon: 'spotLight' as const,
+    createHelper: (light: SpotLight) =>
+      new SpotLightHelper(light, selectionColor),
+  },
+  directionalLight: {
+    ...extendObjectProps(baseObjectConfig, {
+      intensity: createNumberPropConfig('intensity', 1),
+    }),
+    icon: 'sun' as const,
+    dimensionless: true,
+    createHelper: (light: DirectionalLight) =>
+      new DirectionalLightHelper(light, 1, selectionColor),
+  },
+  pointLight: {
+    ...baseLightConfig,
+    icon: 'lightBulb' as const,
+    createHelper: (light: PointLight) =>
+      new PointLightHelper(light, 1, selectionColor),
+  },
+  perspectiveCamera: extendObjectProps(baseCameraConfig, {
+    fov: createNumberPropConfig('fov', 50),
+    zoom: createNumberPropConfig('zoom', 1),
+  }),
+  orthographicCamera: baseCameraConfig,
+}
+
+// Assert that the config is indeed of EditableFactoryConfig without actually
+// forcing it to that type so that we can pass the real type to the editable factory
+defaultEditableFactoryConfig as EditableFactoryConfig
+
+export default defaultEditableFactoryConfig

--- a/packages/r3f/src/defaultEditableFactoryConfig.ts
+++ b/packages/r3f/src/defaultEditableFactoryConfig.ts
@@ -1,5 +1,4 @@
-import type {
-  EditableFactoryConfig} from './editableFactoryConfigUtils';
+import type {EditableFactoryConfig} from './editableFactoryConfigUtils'
 import {
   createNumberPropConfig,
   createVector,
@@ -12,7 +11,8 @@ import type {
   OrthographicCamera,
   PerspectiveCamera,
   PointLight,
-  SpotLight} from 'three';
+  SpotLight,
+} from 'three'
 import {
   BoxHelper,
   CameraHelper,
@@ -28,6 +28,8 @@ const baseObjectConfig = {
     scale: createVectorPropConfig('scale', createVector([1, 1, 1])),
   },
   useTransformControls: true,
+  icon: 'cube' as const,
+  createHelper: (object: Object3D) => new BoxHelper(object, selectionColor),
 }
 
 const baseLightConfig = {
@@ -94,6 +96,10 @@ const defaultEditableFactoryConfig = {
     zoom: createNumberPropConfig('zoom', 1),
   }),
   orthographicCamera: baseCameraConfig,
+  points: baseObjectConfig,
+  line: baseObjectConfig,
+  lineLoop: baseObjectConfig,
+  lineSegments: baseObjectConfig,
 }
 
 // Assert that the config is indeed of EditableFactoryConfig without actually

--- a/packages/r3f/src/defaultEditableFactoryConfig.ts
+++ b/packages/r3f/src/defaultEditableFactoryConfig.ts
@@ -43,8 +43,8 @@ const baseLightConfig = {
 
 const baseCameraConfig = {
   ...extendObjectProps(baseObjectConfig, {
-    near: createNumberPropConfig('near', 0.1),
-    far: createNumberPropConfig('far', 2000),
+    near: createNumberPropConfig('near', 0.1, {nudgeMultiplier: 0.1}),
+    far: createNumberPropConfig('far', 2000, {nudgeMultiplier: 0.1}),
   }),
   updateObject: (camera: PerspectiveCamera | OrthographicCamera) => {
     camera.updateProjectionMatrix()
@@ -69,8 +69,8 @@ const defaultEditableFactoryConfig = {
   },
   spotLight: {
     ...extendObjectProps(baseLightConfig, {
-      angle: createNumberPropConfig('angle'),
-      penumbra: createNumberPropConfig('penumbra'),
+      angle: createNumberPropConfig('angle', 0, {nudgeMultiplier: 0.001}),
+      penumbra: createNumberPropConfig('penumbra', 0, {nudgeMultiplier: 0.001}),
     }),
     icon: 'spotLight' as const,
     createHelper: (light: SpotLight) =>
@@ -92,7 +92,7 @@ const defaultEditableFactoryConfig = {
       new PointLightHelper(light, 1, selectionColor),
   },
   perspectiveCamera: extendObjectProps(baseCameraConfig, {
-    fov: createNumberPropConfig('fov', 50),
+    fov: createNumberPropConfig('fov', 50, {nudgeMultiplier: 0.1}),
     zoom: createNumberPropConfig('zoom', 1),
   }),
   orthographicCamera: baseCameraConfig,

--- a/packages/r3f/src/editableFactoryConfigUtils.ts
+++ b/packages/r3f/src/editableFactoryConfigUtils.ts
@@ -28,6 +28,7 @@ type PropConfig<T> = {
 export const createVectorPropConfig = (
   key: string,
   defaultValue = createVector(),
+  {nudgeMultiplier = 0.01} = {},
 ): PropConfig<Vector3> => ({
   parse: (props) => {
     const vector = props[key]
@@ -50,9 +51,9 @@ export const createVectorPropConfig = (
   },
   type: {
     [key]: {
-      x: types.number(defaultValue.x, {nudgeMultiplier: 0.1}),
-      y: types.number(defaultValue.y, {nudgeMultiplier: 0.1}),
-      z: types.number(defaultValue.z, {nudgeMultiplier: 0.1}),
+      x: types.number(defaultValue.x, {nudgeMultiplier}),
+      y: types.number(defaultValue.y, {nudgeMultiplier}),
+      z: types.number(defaultValue.z, {nudgeMultiplier}),
     },
   },
 })
@@ -60,6 +61,7 @@ export const createVectorPropConfig = (
 export const createNumberPropConfig = (
   key: string,
   defaultValue: number = 0,
+  {nudgeMultiplier = 0.01} = {},
 ): PropConfig<number> => ({
   parse: (props) => {
     return props[key] ?? defaultValue ?? 0
@@ -68,7 +70,7 @@ export const createNumberPropConfig = (
     object[key] = value
   },
   type: {
-    [key]: types.number(defaultValue, {nudgeMultiplier: 0.01}),
+    [key]: types.number(defaultValue, {nudgeMultiplier}),
   },
 })
 

--- a/packages/r3f/src/editableFactoryConfigUtils.ts
+++ b/packages/r3f/src/editableFactoryConfigUtils.ts
@@ -3,6 +3,27 @@ import {types} from '@theatre/core'
 import type {Object3D} from 'three'
 import type {IconID} from './icons'
 
+export type Helper = Object3D & {
+  update?: () => void
+}
+type PropConfig<T> = {
+  parse: (props: Record<string, any>) => T
+  apply: (value: T, object: any) => void
+  type: IShorthandCompoundProps
+}
+type Props = Record<string, PropConfig<any>>
+type Meta<T> = {
+  useTransformControls: boolean
+  updateObject?: (object: T) => void
+  icon: IconID
+  dimensionless?: boolean
+  createHelper: (object: T) => Helper
+}
+export type ObjectConfig<T> = {props: Props} & Meta<T>
+export type EditableFactoryConfig = Partial<
+  Record<keyof JSX.IntrinsicElements, ObjectConfig<any>>
+>
+
 type Vector3 = {
   x: number
   y: number
@@ -17,12 +38,6 @@ export const createVector = (components?: [number, number, number]) => {
         y: 0,
         z: 0,
       }
-}
-
-type PropConfig<T> = {
-  parse: (props: Record<string, any>) => T
-  apply: (value: T, object: any) => void
-  type: IShorthandCompoundProps
 }
 
 export const createVectorPropConfig = (
@@ -73,25 +88,6 @@ export const createNumberPropConfig = (
     [key]: types.number(defaultValue, {nudgeMultiplier}),
   },
 })
-
-export type Helper = Object3D & {
-  update?: () => void
-}
-
-type Props = Record<string, any>
-type Meta<T> = {
-  useTransformControls: boolean
-  updateObject?: (object: T) => void
-  icon: IconID
-  dimensionless?: boolean
-  createHelper: (object: T) => Helper
-}
-
-export type ObjectConfig<T> = {props: Props} & Meta<T>
-
-export type EditableFactoryConfig = Partial<
-  Record<keyof JSX.IntrinsicElements, ObjectConfig<any>>
->
 
 export const extendObjectProps = <T extends {props: {}}>(
   objectConfig: T,

--- a/packages/r3f/src/editableFactoryConfigUtils.ts
+++ b/packages/r3f/src/editableFactoryConfigUtils.ts
@@ -1,0 +1,107 @@
+import type {IShorthandCompoundProps} from '@theatre/core';
+import { types} from '@theatre/core'
+import type {Object3D} from 'three'
+
+type Vector3 = {
+  x: number
+  y: number
+  z: number
+}
+
+export const createVector = (components?: [number, number, number]) => {
+  return components
+    ? {x: components[0], y: components[1], z: components[2]}
+    : {
+        x: 0,
+        y: 0,
+        z: 0,
+      }
+}
+
+type PropConfig<T> = {
+  parse: (props: Record<string, any>) => T
+  apply: (value: T, object: any) => void
+  type: IShorthandCompoundProps
+}
+
+export const createVectorPropConfig = (
+  key: string,
+  defaultValue = createVector(),
+): PropConfig<Vector3> => ({
+  parse: (props) => {
+    const vector = props[key]
+      ? Array.isArray(props[key])
+        ? createVector(props[key] as any)
+        : {
+            x: props[key].x,
+            y: props[key].y,
+            z: props[key].z,
+          }
+      : defaultValue
+    ;(['x', 'y', 'z'] as const).forEach((axis) => {
+      if (props[`${key}-${axis}` as any])
+        vector[axis] = props[`${key}-${axis}` as any]
+    })
+    return vector
+  },
+  apply: (value, object) => {
+    object[key].set(value.x, value.y, value.z)
+  },
+  type: {
+    [key]: {
+      x: types.number(defaultValue.x, {nudgeMultiplier: 0.1}),
+      y: types.number(defaultValue.y, {nudgeMultiplier: 0.1}),
+      z: types.number(defaultValue.z, {nudgeMultiplier: 0.1}),
+    },
+  },
+})
+
+export const createNumberPropConfig = (
+  key: string,
+  defaultValue: number = 0,
+): PropConfig<number> => ({
+  parse: (props) => {
+    return props[key] ?? defaultValue ?? 0
+  },
+  apply: (value, object) => {
+    object[key] = value
+  },
+  type: {
+    [key]: types.number(defaultValue, {nudgeMultiplier: 0.01}),
+  },
+})
+
+export type IconID =
+  | 'collection'
+  | 'cube'
+  | 'lightBulb'
+  | 'spotLight'
+  | 'sun'
+  | 'camera'
+
+export type Helper = Object3D & {
+  update?: () => void
+}
+
+type Props = Record<string, any>
+type Meta<T> = {
+  useTransformControls: boolean
+  updateObject?: (object: T) => void
+  icon: IconID
+  dimensionless?: boolean
+  createHelper: (object: T) => Helper
+}
+
+export type ObjectConfig<T> = {props: Props} & Meta<T>
+
+export type EditableFactoryConfig = Partial<
+  Record<keyof JSX.IntrinsicElements, ObjectConfig<any>>
+>
+
+export const extendObjectProps = <T extends {props: {}}>(
+  objectConfig: T,
+  extension: Props,
+) => ({
+  ...objectConfig,
+  props: {...objectConfig.props, ...extension},
+})

--- a/packages/r3f/src/editableFactoryConfigUtils.ts
+++ b/packages/r3f/src/editableFactoryConfigUtils.ts
@@ -1,6 +1,7 @@
-import type {IShorthandCompoundProps} from '@theatre/core';
-import { types} from '@theatre/core'
+import type {IShorthandCompoundProps} from '@theatre/core'
+import {types} from '@theatre/core'
 import type {Object3D} from 'three'
+import type {IconID} from './icons'
 
 type Vector3 = {
   x: number
@@ -70,14 +71,6 @@ export const createNumberPropConfig = (
     [key]: types.number(defaultValue, {nudgeMultiplier: 0.01}),
   },
 })
-
-export type IconID =
-  | 'collection'
-  | 'cube'
-  | 'lightBulb'
-  | 'spotLight'
-  | 'sun'
-  | 'camera'
 
 export type Helper = Object3D & {
   update?: () => void

--- a/packages/r3f/src/icons.tsx
+++ b/packages/r3f/src/icons.tsx
@@ -1,0 +1,19 @@
+import {BsCameraVideoFill, BsFillCollectionFill} from 'react-icons/bs'
+import {GiCube, GiLightBulb, GiLightProjector} from 'react-icons/gi'
+import {BiSun} from 'react-icons/bi'
+import type {ReactNode} from 'react';
+import React from 'react'
+import type {IconID} from './editableFactoryConfigUtils'
+
+const icons: {
+  [Key in IconID]: ReactNode
+} = {
+  collection: <BsFillCollectionFill />,
+  cube: <GiCube />,
+  lightBulb: <GiLightBulb />,
+  spotLight: <GiLightProjector />,
+  sun: <BiSun />,
+  camera: <BsCameraVideoFill pointerEvents="none" />,
+}
+
+export default icons

--- a/packages/r3f/src/icons.tsx
+++ b/packages/r3f/src/icons.tsx
@@ -1,19 +1,17 @@
 import {BsCameraVideoFill, BsFillCollectionFill} from 'react-icons/bs'
 import {GiCube, GiLightBulb, GiLightProjector} from 'react-icons/gi'
 import {BiSun} from 'react-icons/bi'
-import type {ReactNode} from 'react';
 import React from 'react'
-import type {IconID} from './editableFactoryConfigUtils'
 
-const icons: {
-  [Key in IconID]: ReactNode
-} = {
+const icons = {
   collection: <BsFillCollectionFill />,
   cube: <GiCube />,
   lightBulb: <GiLightBulb />,
   spotLight: <GiLightProjector />,
   sun: <BiSun />,
-  camera: <BsCameraVideoFill pointerEvents="none" />,
+  camera: <BsCameraVideoFill />,
 }
+
+export type IconID = keyof typeof icons
 
 export default icons

--- a/packages/r3f/src/store.ts
+++ b/packages/r3f/src/store.ts
@@ -3,172 +3,61 @@ import create from 'zustand'
 import type {Object3D, Scene, WebGLRenderer} from 'three'
 import {Group} from 'three'
 import type {ISheetObject} from '@theatre/core'
-import {types} from '@theatre/core'
-
-export type EditableType =
-  | 'group'
-  | 'mesh'
-  | 'spotLight'
-  | 'directionalLight'
-  | 'pointLight'
-  | 'perspectiveCamera'
-  | 'orthographicCamera'
+import type {ObjectConfig} from './editableFactoryConfigUtils'
 
 export type TransformControlsMode = 'translate' | 'rotate' | 'scale'
 export type TransformControlsSpace = 'world' | 'local'
 export type ViewportShading = 'wireframe' | 'flat' | 'solid' | 'rendered'
 
-const positionComp = types.number(1, {nudgeMultiplier: 0.1})
-const rotationComp = types.number(1, {nudgeMultiplier: 0.02})
-const scaleComp = types.number(1, {nudgeMultiplier: 0.1})
-
-export const baseSheetObjectType = {
-  position: {
-    x: positionComp,
-    y: positionComp,
-    z: positionComp,
-  },
-  rotation: {
-    x: rotationComp,
-    y: rotationComp,
-    z: rotationComp,
-  },
-  scale: {
-    x: scaleComp,
-    y: scaleComp,
-    z: scaleComp,
-  },
-}
-
-export type BaseSheetObjectType = ISheetObject<typeof baseSheetObjectType>
+export type BaseSheetObjectType = ISheetObject<any>
 
 export const allRegisteredObjects = new WeakSet<BaseSheetObjectType>()
 
-export interface AbstractEditable<T extends EditableType> {
-  type: T
-  role: 'active' | 'removed'
-  sheetObject?: ISheetObject<any>
+export interface Editable<T> {
+  type: string
+  sheetObject: ISheetObject<any>
+  objectConfig: ObjectConfig<T>
+  visibleOnlyInEditor: boolean
 }
 
-// all these identical types are to prepare for a future in which different object types have different properties
-export interface EditableGroup extends AbstractEditable<'group'> {
-  sheetObject?: BaseSheetObjectType
-}
-
-export interface EditableMesh extends AbstractEditable<'mesh'> {
-  sheetObject?: BaseSheetObjectType
-}
-
-export interface EditableSpotLight extends AbstractEditable<'spotLight'> {
-  sheetObject?: BaseSheetObjectType
-}
-
-export interface EditableDirectionalLight
-  extends AbstractEditable<'directionalLight'> {
-  sheetObject?: BaseSheetObjectType
-}
-
-export interface EditablePointLight extends AbstractEditable<'pointLight'> {
-  sheetObject?: BaseSheetObjectType
-}
-
-export interface EditablePerspectiveCamera
-  extends AbstractEditable<'perspectiveCamera'> {
-  sheetObject?: BaseSheetObjectType
-}
-
-export interface EditableOrthographicCamera
-  extends AbstractEditable<'orthographicCamera'> {
-  sheetObject?: BaseSheetObjectType
-}
-
-export type Editable =
-  | EditableGroup
-  | EditableMesh
-  | EditableSpotLight
-  | EditableDirectionalLight
-  | EditablePointLight
-  | EditablePerspectiveCamera
-  | EditableOrthographicCamera
-
-export type EditableSnapshot<T extends Editable = Editable> = {
+export type EditableSnapshot<T extends Editable<any> = Editable<any>> = {
   proxyObject?: Object3D | null
 } & T
 
-export interface AbstractSerializedEditable<T extends EditableType> {
-  type: T
+export interface SerializedEditable {
+  type: string
 }
-
-export interface SerializedEditableGroup
-  extends AbstractSerializedEditable<'group'> {}
-
-export interface SerializedEditableMesh
-  extends AbstractSerializedEditable<'mesh'> {}
-
-export interface SerializedEditableSpotLight
-  extends AbstractSerializedEditable<'spotLight'> {}
-
-export interface SerializedEditableDirectionalLight
-  extends AbstractSerializedEditable<'directionalLight'> {}
-
-export interface SerializedEditablePointLight
-  extends AbstractSerializedEditable<'pointLight'> {}
-
-export interface SerializedEditablePerspectiveCamera
-  extends AbstractSerializedEditable<'perspectiveCamera'> {}
-
-export interface SerializedEditableOrthographicCamera
-  extends AbstractSerializedEditable<'orthographicCamera'> {}
-
-export type SerializedEditable =
-  | SerializedEditableGroup
-  | SerializedEditableMesh
-  | SerializedEditableSpotLight
-  | SerializedEditableDirectionalLight
-  | SerializedEditablePointLight
-  | SerializedEditablePerspectiveCamera
-  | SerializedEditableOrthographicCamera
 
 export interface EditableState {
   editables: Record<string, SerializedEditable>
 }
 
 export type EditorStore = {
-  sheetObjects: {[uniqueName in string]?: BaseSheetObjectType}
   scene: Scene | null
   gl: WebGLRenderer | null
-  allowImplicitInstancing: boolean
   helpersRoot: Group
-  editables: Record<string, Editable>
+  editables: Record<string, Editable<any>>
   // this will come in handy when we start supporting multiple canvases
   canvasName: string
   sceneSnapshot: Scene | null
   editablesSnapshot: Record<string, EditableSnapshot> | null
 
-  init: (
-    scene: Scene,
-    gl: WebGLRenderer,
-    allowImplicitInstancing: boolean,
-  ) => void
+  init: (scene: Scene, gl: WebGLRenderer) => void
 
-  addEditable: <T extends EditableType>(type: T, uniqueName: string) => void
-  removeEditable: (uniqueName: string) => void
+  addEditable: (uniqueName: string, editable: Editable<any>) => void
   createSnapshot: () => void
-  setSheetObject: (uniqueName: string, sheetObject: BaseSheetObjectType) => void
   setSnapshotProxyObject: (
     proxyObject: Object3D | null,
     uniqueName: string,
   ) => void
 }
 
-const config: StateCreator<EditorStore> = (set, get) => {
+const config: StateCreator<EditorStore> = (set) => {
   return {
     sheet: null,
     editorObject: null,
-    sheetObjects: {},
     scene: null,
     gl: null,
-    allowImplicitInstancing: false,
     helpersRoot: new Group(),
     editables: {},
     canvasName: 'default',
@@ -176,65 +65,18 @@ const config: StateCreator<EditorStore> = (set, get) => {
     editablesSnapshot: null,
     initialEditorCamera: {},
 
-    init: (scene, gl, allowImplicitInstancing) => {
+    init: (scene, gl) => {
       set({
         scene,
         gl,
-        allowImplicitInstancing,
       })
     },
 
-    addEditable: (type, uniqueName) =>
-      set((state) => {
-        if (state.editables[uniqueName]) {
-          if (
-            state.editables[uniqueName].type !== type &&
-            process.env.NODE_ENV === 'development'
-          ) {
-            console.error(`Warning: There is a mismatch between the serialized type of ${uniqueName} and the one set when adding it to the scene.
-  Serialized: ${state.editables[uniqueName].type}.
-  Current: ${type}.
-  
-  This might have happened either because you changed the type of an object, in which case a re-export will solve the issue, or because you re-used the uniqueName for an object of a different type, which is an error.`)
-          }
-          if (
-            state.editables[uniqueName].role === 'active' &&
-            !state.allowImplicitInstancing
-          ) {
-            throw Error(
-              `Scene already has an editable object named ${uniqueName}.
-  If this is intentional, please set the allowImplicitInstancing prop of EditableManager to true.`,
-            )
-          } else {
-          }
-        }
-
-        return {
-          editables: {
-            ...state.editables,
-            [uniqueName]: {
-              type: type as EditableType,
-              role: 'active',
-            },
-          },
-        }
-      }),
-
-    removeEditable: (name) =>
-      set((state) => {
-        const {[name]: removed, ...rest} = state.editables
-        return {
-          editables: {
-            ...rest,
-            [name]: {...removed, role: 'removed'},
-          },
-        }
-      }),
-    setSheetObject: (uniqueName, sheetObject) => {
+    addEditable: (uniqueName, editable) => {
       set((state) => ({
-        sheetObjects: {
-          ...state.sheetObjects,
-          [uniqueName]: sheetObject,
+        editables: {
+          ...state.editables,
+          [uniqueName]: editable,
         },
       }))
     },
@@ -245,6 +87,7 @@ const config: StateCreator<EditorStore> = (set, get) => {
         editablesSnapshot: state.editables,
       }))
     },
+
     setSnapshotProxyObject: (proxyObject, uniqueName) => {
       set((state) => ({
         editablesSnapshot: {
@@ -267,11 +110,7 @@ export type BindFunction = (options: {
   scene: Scene
 }) => void
 
-export const bindToCanvas: BindFunction = ({
-  allowImplicitInstancing = false,
-  gl,
-  scene,
-}) => {
+export const bindToCanvas: BindFunction = ({gl, scene}) => {
   const init = useEditorStore.getState().init
-  init(scene, gl, allowImplicitInstancing)
+  init(scene, gl)
 }

--- a/theatre/core/src/index.ts
+++ b/theatre/core/src/index.ts
@@ -12,6 +12,7 @@ export type {
 export type {ISequence} from '@theatre/core/sequences/TheatreSequence'
 export type {ISheetObject} from '@theatre/core/sheetObjects/TheatreSheetObject'
 export type {ISheet} from '@theatre/core/sheets/TheatreSheet'
+export type {IShorthandCompoundProps} from '@theatre/core/propTypes'
 import * as globalVariableNames from '@theatre/shared/globalVariableNames'
 import type StudioBundle from '@theatre/studio/StudioBundle'
 import CoreBundle from './CoreBundle'

--- a/theatre/core/src/propTypes/index.ts
+++ b/theatre/core/src/propTypes/index.ts
@@ -726,3 +726,5 @@ export type PropTypeConfig =
   | PropTypeConfig_AllSimples
   | PropTypeConfig_Compound<$IntentionalAny>
   | PropTypeConfig_Enum
+
+export type {IShorthandCompoundProps}


### PR DESCRIPTION
This PR is centered around one main issue: all objects and their properties are hard-coded in the r3f extension right now. This means that there is not only no possiblity for user-land extension to the supported object types, but it is also hard for us to change or add things to it.

This PR solves it by creating and editable factory function that takes a schema and creates the editable component based on that schema.

This way all the things necessary for supporting an object (properties, how they translate to theatre, whether they have transform controls, what icons to use for them in the side bar, what helper to display in the viewport, etc) can be defined in a single place with a few lines of code.

---

This PR ended up doing a bunch of things. First off, the schema definition.

The schema is of shape
```ts
export type Helper = Object3D & {
  update?: () => void
}
type PropConfig<T> = {
  parse: (props: Record<string, any>) => T
  apply: (value: T, object: any) => void
  type: IShorthandCompoundProps
}
type Props = Record<string, PropConfig<any>>
type Meta<T> = {
  useTransformControls: boolean
  updateObject?: (object: T) => void
  icon: IconID
  dimensionless?: boolean
  createHelper: (object: T) => Helper
}
export type ObjectConfig<T> = {props: Props} & Meta<T>
export type EditableFactoryConfig = Partial<
  Record<keyof JSX.IntrinsicElements, ObjectConfig<any>>
>
```

and lets us define all that is needed for the r3f extension to support a certain set of objects.

Prop configs let us support arbitrary properties that are defined through an arbitrary set of props passed to the react component. It does this through
- the `parse()` function that receives all the props passed, and returns the initial value of the theatre prop
- the `apply()` function that applies values received from theatre to the object

Second, the PR improves the UX of the viewport. Helpers are no longer displayed for dimensionless objects all the time, cluttering the viewport, only for hovered and selected objects. Selection colors are also aligned with theatre designs.

Third, it expands the number of supported objects with points, lines, line segments and line loops and makes the most common properties of existing objects editable, e.g. angle, penumbra and intensity for spotlights.

In the future the schema API and the editable factory will be exposed to users so anyone can extend the supported objects if the default set doesn't cover their needs.