### PR TITLE
Add method to clear persistent storage

### DIFF
--- a/theatre/studio/src/Studio.ts
+++ b/theatre/studio/src/Studio.ts
@@ -519,6 +519,6 @@ export class Studio {
   }
 
   clearPersistentStorage(persistenceKey = DEFAULT_PERSISTENCE_KEY) {
-    this._store.clearPersistentStorage(persistenceKey)
+    this._store.__experimental_clearPersistentStorage(persistenceKey)
   }
 }

--- a/theatre/studio/src/Studio.ts
+++ b/theatre/studio/src/Studio.ts
@@ -28,6 +28,8 @@ import {getAllPossibleAssetIDs} from '@theatre/shared/utils/assets'
 import {notify} from './notify'
 import type {RafDriverPrivateAPI} from '@theatre/core/rafDrivers'
 
+const DEFAULT_PERSISTENCE_KEY = 'theatre-0.4'
+
 export type CoreExports = typeof _coreExports
 
 const UIConstructorModule =
@@ -159,7 +161,7 @@ export class Studio {
     }
 
     const storeOpts: Parameters<typeof this._store['initialize']>[0] = {
-      persistenceKey: 'theatre-0.4',
+      persistenceKey: DEFAULT_PERSISTENCE_KEY,
       usePersistentStorage: true,
     }
 
@@ -514,5 +516,9 @@ export class Studio {
         return asset.name
       },
     }
+  }
+
+  clearPersistentStorage(persistenceKey = DEFAULT_PERSISTENCE_KEY) {
+    this._store.clearPersistentStorage(persistenceKey)
   }
 }

--- a/theatre/studio/src/StudioStore/StudioStore.ts
+++ b/theatre/studio/src/StudioStore/StudioStore.ts
@@ -20,7 +20,10 @@ import type {Atom, Pointer} from '@theatre/dataverse'
 import type {Draft} from 'immer'
 import {createDraft, finishDraft} from 'immer'
 import type {Store} from 'redux'
-import {persistStateOfStudio} from './persistStateOfStudio'
+import {
+  clearPersistentStorage,
+  persistStateOfStudio,
+} from './persistStateOfStudio'
 import type {OnDiskState} from '@theatre/core/projects/store/storeTypes'
 import {generateDiskStateRevision} from './generateDiskStateRevision'
 
@@ -87,6 +90,11 @@ export default class StudioStore {
 
   getState(): FullStudioState {
     return this._reduxStore.getState()
+  }
+
+  clearPersistentStorage(persistenceKey: string): FullStudioState {
+    clearPersistentStorage(this._reduxStore, persistenceKey)
+    return this.getState()
   }
 
   /**

--- a/theatre/studio/src/StudioStore/StudioStore.ts
+++ b/theatre/studio/src/StudioStore/StudioStore.ts
@@ -21,7 +21,7 @@ import type {Draft} from 'immer'
 import {createDraft, finishDraft} from 'immer'
 import type {Store} from 'redux'
 import {
-  clearPersistentStorage,
+  __experimental_clearPersistentStorage,
   persistStateOfStudio,
 } from './persistStateOfStudio'
 import type {OnDiskState} from '@theatre/core/projects/store/storeTypes'
@@ -92,8 +92,10 @@ export default class StudioStore {
     return this._reduxStore.getState()
   }
 
-  clearPersistentStorage(persistenceKey: string): FullStudioState {
-    clearPersistentStorage(this._reduxStore, persistenceKey)
+  __experimental_clearPersistentStorage(
+    persistenceKey: string,
+  ): FullStudioState {
+    __experimental_clearPersistentStorage(this._reduxStore, persistenceKey)
     return this.getState()
   }
 

--- a/theatre/studio/src/StudioStore/persistStateOfStudio.ts
+++ b/theatre/studio/src/StudioStore/persistStateOfStudio.ts
@@ -19,7 +19,7 @@ export const persistStateOfStudio = (
     reduxStore.dispatch(studioActions.replacePersistentState(s))
   }
 
-  const storageKey = localStoragePrefix + '.persistent'
+  const storageKey = getStorageKey(localStoragePrefix)
   const getState = () => reduxStore.getState().$persistent
 
   loadFromPersistentStorage()
@@ -60,14 +60,21 @@ export const persistStateOfStudio = (
   }
 }
 
-export const clearPersistentStorage = (
+export const __experimental_clearPersistentStorage = (
   reduxStore: Store<FullStudioState>,
   localStoragePrefix: string,
 ) => {
-  const storageKey = localStoragePrefix + '.persistent'
+  // This removes the persisted state from localStorage,
+  // while also preventing the current state from being persisted on window unload.
+  // Once the new storage PR lands, this method won't be needed anymore.
+  const storageKey = getStorageKey(localStoragePrefix)
   const currentState = reduxStore.getState().$persistent
   localStorage.removeItem(storageKey)
   // prevent the current state from being persistent on window unload,
   // unless further state changes are made.
   lastStateByStore.set(reduxStore, currentState)
+}
+
+function getStorageKey(localStoragePrefix: string) {
+  return localStoragePrefix + '.persistent'
 }

--- a/theatre/studio/src/TheatreStudio.ts
+++ b/theatre/studio/src/TheatreStudio.ts
@@ -410,6 +410,14 @@ export interface IStudio {
      */
     __experimental_enablePlayPauseKeyboardShortcut(): void
   }
+  /**
+   * Clears persistent storage and ensures that the current state will not be
+   * saved on window unload. Further changes to state will continue writing to
+   * persistent storage, if enabled during initialization.
+   *
+   * @param persistenceKey - same persistencyKey as in `studio.initialize(opts)`, if any
+   */
+  clearPersistentStorage(persistenceKey?: string): void
 }
 
 export default class TheatreStudio implements IStudio {
@@ -566,5 +574,9 @@ export default class TheatreStudio implements IStudio {
     return getStudio().createContentOfSaveFile(
       projectId as ProjectId,
     ) as $IntentionalAny
+  }
+
+  clearPersistentStorage(persistenceKey?: string): void {
+    return getStudio().clearPersistentStorage(persistenceKey)
   }
 }

--- a/theatre/studio/src/TheatreStudio.ts
+++ b/theatre/studio/src/TheatreStudio.ts
@@ -409,15 +409,15 @@ export interface IStudio {
      * Disables the play/pause keyboard shortcut (spacebar)
      */
     __experimental_enablePlayPauseKeyboardShortcut(): void
+    /**
+     * Clears persistent storage and ensures that the current state will not be
+     * saved on window unload. Further changes to state will continue writing to
+     * persistent storage, if enabled during initialization.
+     *
+     * @param persistenceKey - same persistencyKey as in `studio.initialize(opts)`, if any
+     */
+    __experimental_clearPersistentStorage(persistenceKey?: string): void
   }
-  /**
-   * Clears persistent storage and ensures that the current state will not be
-   * saved on window unload. Further changes to state will continue writing to
-   * persistent storage, if enabled during initialization.
-   *
-   * @param persistenceKey - same persistencyKey as in `studio.initialize(opts)`, if any
-   */
-  clearPersistentStorage(persistenceKey?: string): void
 }
 
 export default class TheatreStudio implements IStudio {
@@ -453,6 +453,9 @@ export default class TheatreStudio implements IStudio {
     __experimental_enablePlayPauseKeyboardShortcut(): void {
       // see __experimental_disblePlayPauseKeyboardShortcut()
       __experimental_enablePlayPauseKeyboardShortcut()
+    },
+    __experimental_clearPersistentStorage(persistenceKey?: string): void {
+      return getStudio().clearPersistentStorage(persistenceKey)
     },
   }
 
@@ -574,9 +577,5 @@ export default class TheatreStudio implements IStudio {
     return getStudio().createContentOfSaveFile(
       projectId as ProjectId,
     ) as $IntentionalAny
-  }
-
-  clearPersistentStorage(persistenceKey?: string): void {
-    return getStudio().clearPersistentStorage(persistenceKey)
   }
 }


### PR DESCRIPTION
Possible solution to an issue we discussed briefly in Discord — our application registers an extension, and displays a button allowing users to save their changes to a file. We enable persistent storage in case the page crashes or reloads before changes have been saved. In some cases the user may decide _not_ to save the changes they've made since the last save, in which case we need a way to clear persistent storage.

I've tried just clearing all localstorage entries with the right prefix and then reloading, but then theatre.js is doing one last commit to localstorage before the page reloads and the cache persists. This PR would expose a new method, `studio.clearPersistentStorage()`, which could be used by userland code or extensions.

*This contribution is funded by The New York Times.*