### PR TITLE
Publish the development versions of the packages as tarballs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,22 +44,22 @@ jobs:
             ${{ runner.os }}-dev-package-uploader-cache-
 
       - run: yarn install
-      # - run: yarn typecheck
-      # - run: yarn lint:all --max-warnings 0
-      # - run: yarn test
-      # - name: Download playwright
-      #   run: yarn workspace playground run playwright install
-      # - name: Run e2e tests with percy
-      #   uses: percy/exec-action@v0.3.1
-      #   with:
-      #     custom-command: 'yarn test:e2e:ci'
-      #   env:
-      #     PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+      - run: yarn typecheck
+      - run: yarn lint:all --max-warnings 0
+      - run: yarn test
+      - name: Download playwright
+        run: yarn workspace playground run playwright install
+      - name: Run e2e tests with percy
+        uses: percy/exec-action@v0.3.1
+        with:
+          custom-command: 'yarn test:e2e:ci'
+        env:
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
       - name: Install dependencies of the dev-package-uploader
         working-directory: ${{ github.workspace }}/scripts/dev-package-uploader
         run: npm install
-      # - name: Build the theatre packages
-      #   run: yarn build
+      - name: Build the theatre packages
+        run: yarn build
       - name: Publish the packages
         env:
           DO_REGION: 'nyc3'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,17 +44,17 @@ jobs:
             ${{ runner.os }}-dev-package-uploader-cache-
 
       - run: yarn install
-      - run: yarn typecheck
-      - run: yarn lint:all --max-warnings 0
-      - run: yarn test
-      - name: Download playwright
-        run: yarn workspace playground run playwright install
-      - name: Run e2e tests with percy
-        uses: percy/exec-action@v0.3.1
-        with:
-          custom-command: 'yarn test:e2e:ci'
-        env:
-          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+      # - run: yarn typecheck
+      # - run: yarn lint:all --max-warnings 0
+      # - run: yarn test
+      # - name: Download playwright
+      #   run: yarn workspace playground run playwright install
+      # - name: Run e2e tests with percy
+      #   uses: percy/exec-action@v0.3.1
+      #   with:
+      #     custom-command: 'yarn test:e2e:ci'
+      #   env:
+      #     PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
       - name: Install dependencies of the dev-package-uploader
         working-directory: ${{ github.workspace }}/scripts/dev-package-uploader
         run: npm install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,6 +58,8 @@ jobs:
       - name: Install dependencies of the dev-package-uploader
         working-directory: ${{ github.workspace }}/scripts/dev-package-uploader
         run: npm install
+      - name: Build the theatre packages
+        run: yarn build
       - name: Publish the packages
         env:
           DO_REGION: 'nyc3'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,8 +58,8 @@ jobs:
       - name: Install dependencies of the dev-package-uploader
         working-directory: ${{ github.workspace }}/scripts/dev-package-uploader
         run: npm install
-      - name: Build the theatre packages
-        run: yarn build
+      # - name: Build the theatre packages
+      #   run: yarn build
       - name: Publish the packages
         env:
           DO_REGION: 'nyc3'
@@ -67,6 +67,6 @@ jobs:
           DO_SECRET: ${{ secrets.DO_SPACES_SECRET }}
           DO_API_KEY: ${{ secrets.DO_SPACES_KEY }}
           DO_DOMAIN: ''
-          LATEST_COMMIT_HASH: ${{ github.sha }}
+          LATEST_COMMIT_HASH: ${{ github.event.pull_request.head.sha }}
           FOLDER: '@theatre'
         run: npx zx scripts/generate-development-package-tarballs.mjs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,15 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+      - uses: actions/cache@v2
+        id: dev-package-uploader-cache
+        with:
+          path: '${{ github.workspace }}/dev-package-uploader/node_modules'
+          key:
+            ${{ runner.os }}-dev-package-uploader-cache-${{
+            hashFiles('scripts/dev-package-uploader/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-dev-package-uploader-cache-
 
       - run: yarn install
       - run: yarn typecheck
@@ -45,3 +54,12 @@ jobs:
           custom-command: 'yarn test:e2e:ci'
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+      - name: Install dependencies of the dev-package-uploader
+        working-directory: ${{ github.workspace }}/scripts/dev-package-uploader
+        run: npm install
+      - name: Publish the packages
+        env:
+          BUCKET: my-npm-packages
+          SECRET: ${{ secrets.DO_SPACES_SECRET }}
+          KEY: ${{ secrets.DO_SPACES_KEY }}
+        run: npx zx scripts/generate-development-package-tarballs.mjs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,5 +61,5 @@ jobs:
         env:
           BUCKET: my-npm-packages
           SECRET: ${{ secrets.DO_SPACES_SECRET }}
-          KEY: ${{ secrets.DO_SPACES_KEY }}
+          API_KEY: ${{ secrets.DO_SPACES_KEY }}
         run: npx zx scripts/generate-development-package-tarballs.mjs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,10 @@ jobs:
         run: npm install
       - name: Publish the packages
         env:
-          BUCKET: my-npm-packages
-          SECRET: ${{ secrets.DO_SPACES_SECRET }}
-          API_KEY: ${{ secrets.DO_SPACES_KEY }}
+          DO_REGION: 'nyc3'
+          DO_BUCKET: 'theatrejs-packages'
+          DO_SECRET: ${{ secrets.DO_SPACES_SECRET }}
+          DO_API_KEY: ${{ secrets.DO_SPACES_KEY }}
+          DO_DOMAIN: ''
+          FOLDER: '@theatre'
         run: npx zx scripts/generate-development-package-tarballs.mjs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,8 @@ jobs:
       - uses: actions/cache@v2
         id: dev-package-uploader-cache
         with:
-          path: '${{ github.workspace }}/dev-package-uploader/node_modules'
+          path:
+            '${{ github.workspace }}/scripts/dev-package-uploader/node_modules'
           key:
             ${{ runner.os }}-dev-package-uploader-cache-${{
             hashFiles('scripts/dev-package-uploader/package-lock.json') }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,5 +67,6 @@ jobs:
           DO_SECRET: ${{ secrets.DO_SPACES_SECRET }}
           DO_API_KEY: ${{ secrets.DO_SPACES_KEY }}
           DO_DOMAIN: ''
+          LATEST_COMMIT_HASH: ${{ github.sha }}
           FOLDER: '@theatre'
         run: npx zx scripts/generate-development-package-tarballs.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@
 !.yarn/sdks
 !.yarn/versions
 
+# tarballs of the development packages
+theatre-*.tgz

--- a/scripts/dev-package-uploader/package-lock.json
+++ b/scripts/dev-package-uploader/package-lock.json
@@ -1,0 +1,1998 @@
+{
+  "name": "aws-3-uploader",
+  "version": "3.2.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "aws-3-uploader",
+      "version": "3.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "@aws-sdk/client-s3": "^3.80.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "2.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/crc32/node_modules/tslib": {
+      "version": "1.14.1",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "2.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c/node_modules/tslib": {
+      "version": "1.14.1",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-crypto/ie11-detection": {
+      "version": "2.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+      "version": "1.14.1",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "2.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^2.0.0",
+        "@aws-crypto/supports-web-crypto": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "2.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^2.0.0",
+        "@aws-crypto/sha256-js": "^2.0.0",
+        "@aws-crypto/supports-web-crypto": "^2.0.0",
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@aws-crypto/sha256-js": {
+      "version": "2.0.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^2.0.1",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "2.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "2.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+      "version": "1.14.1",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "2.0.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/abort-controller": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/chunked-blob-reader": {
+      "version": "3.55.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/chunked-blob-reader-native": {
+      "version": "3.58.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/util-base64-browser": "3.58.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.80.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "2.0.0",
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.80.0",
+        "@aws-sdk/config-resolver": "3.80.0",
+        "@aws-sdk/credential-provider-node": "3.80.0",
+        "@aws-sdk/eventstream-serde-browser": "3.78.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.78.0",
+        "@aws-sdk/eventstream-serde-node": "3.78.0",
+        "@aws-sdk/fetch-http-handler": "3.78.0",
+        "@aws-sdk/hash-blob-browser": "3.78.0",
+        "@aws-sdk/hash-node": "3.78.0",
+        "@aws-sdk/hash-stream-node": "3.78.0",
+        "@aws-sdk/invalid-dependency": "3.78.0",
+        "@aws-sdk/md5-js": "3.78.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.80.0",
+        "@aws-sdk/middleware-content-length": "3.78.0",
+        "@aws-sdk/middleware-expect-continue": "3.78.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.78.0",
+        "@aws-sdk/middleware-host-header": "3.78.0",
+        "@aws-sdk/middleware-location-constraint": "3.78.0",
+        "@aws-sdk/middleware-logger": "3.78.0",
+        "@aws-sdk/middleware-retry": "3.80.0",
+        "@aws-sdk/middleware-sdk-s3": "3.78.0",
+        "@aws-sdk/middleware-serde": "3.78.0",
+        "@aws-sdk/middleware-signing": "3.78.0",
+        "@aws-sdk/middleware-ssec": "3.78.0",
+        "@aws-sdk/middleware-stack": "3.78.0",
+        "@aws-sdk/middleware-user-agent": "3.78.0",
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/node-http-handler": "3.78.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/signature-v4-multi-region": "3.78.0",
+        "@aws-sdk/smithy-client": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/url-parser": "3.78.0",
+        "@aws-sdk/util-base64-browser": "3.58.0",
+        "@aws-sdk/util-base64-node": "3.55.0",
+        "@aws-sdk/util-body-length-browser": "3.55.0",
+        "@aws-sdk/util-body-length-node": "3.55.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.78.0",
+        "@aws-sdk/util-defaults-mode-node": "3.80.0",
+        "@aws-sdk/util-stream-browser": "3.78.0",
+        "@aws-sdk/util-stream-node": "3.78.0",
+        "@aws-sdk/util-user-agent-browser": "3.78.0",
+        "@aws-sdk/util-user-agent-node": "3.80.0",
+        "@aws-sdk/util-utf8-browser": "3.55.0",
+        "@aws-sdk/util-utf8-node": "3.55.0",
+        "@aws-sdk/util-waiter": "3.78.0",
+        "@aws-sdk/xml-builder": "3.55.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.80.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.80.0",
+        "@aws-sdk/fetch-http-handler": "3.78.0",
+        "@aws-sdk/hash-node": "3.78.0",
+        "@aws-sdk/invalid-dependency": "3.78.0",
+        "@aws-sdk/middleware-content-length": "3.78.0",
+        "@aws-sdk/middleware-host-header": "3.78.0",
+        "@aws-sdk/middleware-logger": "3.78.0",
+        "@aws-sdk/middleware-retry": "3.80.0",
+        "@aws-sdk/middleware-serde": "3.78.0",
+        "@aws-sdk/middleware-stack": "3.78.0",
+        "@aws-sdk/middleware-user-agent": "3.78.0",
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/node-http-handler": "3.78.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/smithy-client": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/url-parser": "3.78.0",
+        "@aws-sdk/util-base64-browser": "3.58.0",
+        "@aws-sdk/util-base64-node": "3.55.0",
+        "@aws-sdk/util-body-length-browser": "3.55.0",
+        "@aws-sdk/util-body-length-node": "3.55.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.78.0",
+        "@aws-sdk/util-defaults-mode-node": "3.80.0",
+        "@aws-sdk/util-user-agent-browser": "3.78.0",
+        "@aws-sdk/util-user-agent-node": "3.80.0",
+        "@aws-sdk/util-utf8-browser": "3.55.0",
+        "@aws-sdk/util-utf8-node": "3.55.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.80.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.80.0",
+        "@aws-sdk/credential-provider-node": "3.80.0",
+        "@aws-sdk/fetch-http-handler": "3.78.0",
+        "@aws-sdk/hash-node": "3.78.0",
+        "@aws-sdk/invalid-dependency": "3.78.0",
+        "@aws-sdk/middleware-content-length": "3.78.0",
+        "@aws-sdk/middleware-host-header": "3.78.0",
+        "@aws-sdk/middleware-logger": "3.78.0",
+        "@aws-sdk/middleware-retry": "3.80.0",
+        "@aws-sdk/middleware-sdk-sts": "3.78.0",
+        "@aws-sdk/middleware-serde": "3.78.0",
+        "@aws-sdk/middleware-signing": "3.78.0",
+        "@aws-sdk/middleware-stack": "3.78.0",
+        "@aws-sdk/middleware-user-agent": "3.78.0",
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/node-http-handler": "3.78.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/smithy-client": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/url-parser": "3.78.0",
+        "@aws-sdk/util-base64-browser": "3.58.0",
+        "@aws-sdk/util-base64-node": "3.55.0",
+        "@aws-sdk/util-body-length-browser": "3.55.0",
+        "@aws-sdk/util-body-length-node": "3.55.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.78.0",
+        "@aws-sdk/util-defaults-mode-node": "3.80.0",
+        "@aws-sdk/util-user-agent-browser": "3.78.0",
+        "@aws-sdk/util-user-agent-node": "3.80.0",
+        "@aws-sdk/util-utf8-browser": "3.55.0",
+        "@aws-sdk/util-utf8-node": "3.55.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/config-resolver": {
+      "version": "3.80.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-config-provider": "3.55.0",
+        "@aws-sdk/util-middleware": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.80.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/url-parser": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.80.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.78.0",
+        "@aws-sdk/credential-provider-imds": "3.80.0",
+        "@aws-sdk/credential-provider-sso": "3.80.0",
+        "@aws-sdk/credential-provider-web-identity": "3.78.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/shared-ini-file-loader": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.80.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.78.0",
+        "@aws-sdk/credential-provider-imds": "3.80.0",
+        "@aws-sdk/credential-provider-ini": "3.80.0",
+        "@aws-sdk/credential-provider-process": "3.80.0",
+        "@aws-sdk/credential-provider-sso": "3.80.0",
+        "@aws-sdk/credential-provider-web-identity": "3.78.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/shared-ini-file-loader": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.80.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/shared-ini-file-loader": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.80.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.80.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/shared-ini-file-loader": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-marshaller": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "2.0.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-hex-encoding": "3.58.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-browser": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/eventstream-marshaller": "3.78.0",
+        "@aws-sdk/eventstream-serde-universal": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-config-resolver": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-node": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/eventstream-marshaller": "3.78.0",
+        "@aws-sdk/eventstream-serde-universal": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-universal": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/eventstream-marshaller": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/querystring-builder": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-base64-browser": "3.58.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/hash-blob-browser": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/chunked-blob-reader": "3.55.0",
+        "@aws-sdk/chunked-blob-reader-native": "3.58.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/hash-node": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-buffer-from": "3.55.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/hash-stream-node": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.55.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/md5-js": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-utf8-browser": "3.55.0",
+        "@aws-sdk/util-utf8-node": "3.55.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.80.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-arn-parser": "3.55.0",
+        "@aws-sdk/util-config-provider": "3.55.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-header-default": "3.78.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "2.0.0",
+        "@aws-crypto/crc32c": "2.0.0",
+        "@aws-sdk/is-array-buffer": "3.55.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-header-default": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.80.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/service-error-classification": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-middleware": "3.78.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-arn-parser": "3.55.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.78.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/signature-v4": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/signature-v4": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.80.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/shared-ini-file-loader": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.78.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/querystring-builder": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/property-provider": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/protocol-http": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-uri-escape": "3.55.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.80.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.55.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-hex-encoding": "3.58.0",
+        "@aws-sdk/util-middleware": "3.78.0",
+        "@aws-sdk/util-uri-escape": "3.55.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/signature-v4": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-arn-parser": "3.55.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/signature-v4-crt": "^3.66.0"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/signature-v4-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/smithy-client": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/url-parser": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.55.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-base64-browser": {
+      "version": "3.58.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-base64-node": {
+      "version": "3.55.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.55.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.55.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.55.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.55.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.55.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.55.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.80.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.80.0",
+        "@aws-sdk/credential-provider-imds": "3.80.0",
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.58.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.55.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-middleware": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-browser": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-node": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.55.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.78.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.80.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.55.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-node": {
+      "version": "3.55.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.55.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-waiter": {
+      "version": "3.78.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.55.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.11.0",
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "2.2.0",
+      "license": "BSD-2-Clause",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "3.19.0",
+      "license": "MIT",
+      "bin": {
+        "xml2js": "cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.4.0",
+      "license": "0BSD"
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    }
+  },
+  "dependencies": {
+    "@aws-crypto/crc32": {
+      "version": "2.0.0",
+      "requires": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1"
+        }
+      }
+    },
+    "@aws-crypto/crc32c": {
+      "version": "2.0.0",
+      "requires": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1"
+        }
+      }
+    },
+    "@aws-crypto/ie11-detection": {
+      "version": "2.0.0",
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1"
+        }
+      }
+    },
+    "@aws-crypto/sha1-browser": {
+      "version": "2.0.0",
+      "requires": {
+        "@aws-crypto/ie11-detection": "^2.0.0",
+        "@aws-crypto/supports-web-crypto": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1"
+        }
+      }
+    },
+    "@aws-crypto/sha256-browser": {
+      "version": "2.0.0",
+      "requires": {
+        "@aws-crypto/ie11-detection": "^2.0.0",
+        "@aws-crypto/sha256-js": "^2.0.0",
+        "@aws-crypto/supports-web-crypto": "^2.0.0",
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "@aws-crypto/sha256-js": {
+          "version": "2.0.1",
+          "requires": {
+            "@aws-crypto/util": "^2.0.1",
+            "@aws-sdk/types": "^3.1.0",
+            "tslib": "^1.11.1"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1"
+        }
+      }
+    },
+    "@aws-crypto/sha256-js": {
+      "version": "2.0.0",
+      "requires": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1"
+        }
+      }
+    },
+    "@aws-crypto/supports-web-crypto": {
+      "version": "2.0.0",
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1"
+        }
+      }
+    },
+    "@aws-crypto/util": {
+      "version": "2.0.1",
+      "requires": {
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1"
+        }
+      }
+    },
+    "@aws-sdk/abort-controller": {
+      "version": "3.78.0",
+      "requires": {
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/chunked-blob-reader": {
+      "version": "3.55.0",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/chunked-blob-reader-native": {
+      "version": "3.58.0",
+      "requires": {
+        "@aws-sdk/util-base64-browser": "3.58.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-s3": {
+      "version": "3.80.0",
+      "requires": {
+        "@aws-crypto/sha1-browser": "2.0.0",
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.80.0",
+        "@aws-sdk/config-resolver": "3.80.0",
+        "@aws-sdk/credential-provider-node": "3.80.0",
+        "@aws-sdk/eventstream-serde-browser": "3.78.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.78.0",
+        "@aws-sdk/eventstream-serde-node": "3.78.0",
+        "@aws-sdk/fetch-http-handler": "3.78.0",
+        "@aws-sdk/hash-blob-browser": "3.78.0",
+        "@aws-sdk/hash-node": "3.78.0",
+        "@aws-sdk/hash-stream-node": "3.78.0",
+        "@aws-sdk/invalid-dependency": "3.78.0",
+        "@aws-sdk/md5-js": "3.78.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.80.0",
+        "@aws-sdk/middleware-content-length": "3.78.0",
+        "@aws-sdk/middleware-expect-continue": "3.78.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.78.0",
+        "@aws-sdk/middleware-host-header": "3.78.0",
+        "@aws-sdk/middleware-location-constraint": "3.78.0",
+        "@aws-sdk/middleware-logger": "3.78.0",
+        "@aws-sdk/middleware-retry": "3.80.0",
+        "@aws-sdk/middleware-sdk-s3": "3.78.0",
+        "@aws-sdk/middleware-serde": "3.78.0",
+        "@aws-sdk/middleware-signing": "3.78.0",
+        "@aws-sdk/middleware-ssec": "3.78.0",
+        "@aws-sdk/middleware-stack": "3.78.0",
+        "@aws-sdk/middleware-user-agent": "3.78.0",
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/node-http-handler": "3.78.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/signature-v4-multi-region": "3.78.0",
+        "@aws-sdk/smithy-client": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/url-parser": "3.78.0",
+        "@aws-sdk/util-base64-browser": "3.58.0",
+        "@aws-sdk/util-base64-node": "3.55.0",
+        "@aws-sdk/util-body-length-browser": "3.55.0",
+        "@aws-sdk/util-body-length-node": "3.55.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.78.0",
+        "@aws-sdk/util-defaults-mode-node": "3.80.0",
+        "@aws-sdk/util-stream-browser": "3.78.0",
+        "@aws-sdk/util-stream-node": "3.78.0",
+        "@aws-sdk/util-user-agent-browser": "3.78.0",
+        "@aws-sdk/util-user-agent-node": "3.80.0",
+        "@aws-sdk/util-utf8-browser": "3.55.0",
+        "@aws-sdk/util-utf8-node": "3.55.0",
+        "@aws-sdk/util-waiter": "3.78.0",
+        "@aws-sdk/xml-builder": "3.55.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-sso": {
+      "version": "3.80.0",
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.80.0",
+        "@aws-sdk/fetch-http-handler": "3.78.0",
+        "@aws-sdk/hash-node": "3.78.0",
+        "@aws-sdk/invalid-dependency": "3.78.0",
+        "@aws-sdk/middleware-content-length": "3.78.0",
+        "@aws-sdk/middleware-host-header": "3.78.0",
+        "@aws-sdk/middleware-logger": "3.78.0",
+        "@aws-sdk/middleware-retry": "3.80.0",
+        "@aws-sdk/middleware-serde": "3.78.0",
+        "@aws-sdk/middleware-stack": "3.78.0",
+        "@aws-sdk/middleware-user-agent": "3.78.0",
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/node-http-handler": "3.78.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/smithy-client": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/url-parser": "3.78.0",
+        "@aws-sdk/util-base64-browser": "3.58.0",
+        "@aws-sdk/util-base64-node": "3.55.0",
+        "@aws-sdk/util-body-length-browser": "3.55.0",
+        "@aws-sdk/util-body-length-node": "3.55.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.78.0",
+        "@aws-sdk/util-defaults-mode-node": "3.80.0",
+        "@aws-sdk/util-user-agent-browser": "3.78.0",
+        "@aws-sdk/util-user-agent-node": "3.80.0",
+        "@aws-sdk/util-utf8-browser": "3.55.0",
+        "@aws-sdk/util-utf8-node": "3.55.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-sts": {
+      "version": "3.80.0",
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.80.0",
+        "@aws-sdk/credential-provider-node": "3.80.0",
+        "@aws-sdk/fetch-http-handler": "3.78.0",
+        "@aws-sdk/hash-node": "3.78.0",
+        "@aws-sdk/invalid-dependency": "3.78.0",
+        "@aws-sdk/middleware-content-length": "3.78.0",
+        "@aws-sdk/middleware-host-header": "3.78.0",
+        "@aws-sdk/middleware-logger": "3.78.0",
+        "@aws-sdk/middleware-retry": "3.80.0",
+        "@aws-sdk/middleware-sdk-sts": "3.78.0",
+        "@aws-sdk/middleware-serde": "3.78.0",
+        "@aws-sdk/middleware-signing": "3.78.0",
+        "@aws-sdk/middleware-stack": "3.78.0",
+        "@aws-sdk/middleware-user-agent": "3.78.0",
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/node-http-handler": "3.78.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/smithy-client": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/url-parser": "3.78.0",
+        "@aws-sdk/util-base64-browser": "3.58.0",
+        "@aws-sdk/util-base64-node": "3.55.0",
+        "@aws-sdk/util-body-length-browser": "3.55.0",
+        "@aws-sdk/util-body-length-node": "3.55.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.78.0",
+        "@aws-sdk/util-defaults-mode-node": "3.80.0",
+        "@aws-sdk/util-user-agent-browser": "3.78.0",
+        "@aws-sdk/util-user-agent-node": "3.80.0",
+        "@aws-sdk/util-utf8-browser": "3.55.0",
+        "@aws-sdk/util-utf8-node": "3.55.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/config-resolver": {
+      "version": "3.80.0",
+      "requires": {
+        "@aws-sdk/signature-v4": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-config-provider": "3.55.0",
+        "@aws-sdk/util-middleware": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-env": {
+      "version": "3.78.0",
+      "requires": {
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-imds": {
+      "version": "3.80.0",
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/url-parser": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-ini": {
+      "version": "3.80.0",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.78.0",
+        "@aws-sdk/credential-provider-imds": "3.80.0",
+        "@aws-sdk/credential-provider-sso": "3.80.0",
+        "@aws-sdk/credential-provider-web-identity": "3.78.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/shared-ini-file-loader": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-node": {
+      "version": "3.80.0",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.78.0",
+        "@aws-sdk/credential-provider-imds": "3.80.0",
+        "@aws-sdk/credential-provider-ini": "3.80.0",
+        "@aws-sdk/credential-provider-process": "3.80.0",
+        "@aws-sdk/credential-provider-sso": "3.80.0",
+        "@aws-sdk/credential-provider-web-identity": "3.78.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/shared-ini-file-loader": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-process": {
+      "version": "3.80.0",
+      "requires": {
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/shared-ini-file-loader": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-sso": {
+      "version": "3.80.0",
+      "requires": {
+        "@aws-sdk/client-sso": "3.80.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/shared-ini-file-loader": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-web-identity": {
+      "version": "3.78.0",
+      "requires": {
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/eventstream-marshaller": {
+      "version": "3.78.0",
+      "requires": {
+        "@aws-crypto/crc32": "2.0.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-hex-encoding": "3.58.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/eventstream-serde-browser": {
+      "version": "3.78.0",
+      "requires": {
+        "@aws-sdk/eventstream-marshaller": "3.78.0",
+        "@aws-sdk/eventstream-serde-universal": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/eventstream-serde-config-resolver": {
+      "version": "3.78.0",
+      "requires": {
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/eventstream-serde-node": {
+      "version": "3.78.0",
+      "requires": {
+        "@aws-sdk/eventstream-marshaller": "3.78.0",
+        "@aws-sdk/eventstream-serde-universal": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/eventstream-serde-universal": {
+      "version": "3.78.0",
+      "requires": {
+        "@aws-sdk/eventstream-marshaller": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/fetch-http-handler": {
+      "version": "3.78.0",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/querystring-builder": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-base64-browser": "3.58.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/hash-blob-browser": {
+      "version": "3.78.0",
+      "requires": {
+        "@aws-sdk/chunked-blob-reader": "3.55.0",
+        "@aws-sdk/chunked-blob-reader-native": "3.58.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/hash-node": {
+      "version": "3.78.0",
+      "requires": {
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-buffer-from": "3.55.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/hash-stream-node": {
+      "version": "3.78.0",
+      "requires": {
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/invalid-dependency": {
+      "version": "3.78.0",
+      "requires": {
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/is-array-buffer": {
+      "version": "3.55.0",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/md5-js": {
+      "version": "3.78.0",
+      "requires": {
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-utf8-browser": "3.55.0",
+        "@aws-sdk/util-utf8-node": "3.55.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.80.0",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-arn-parser": "3.55.0",
+        "@aws-sdk/util-config-provider": "3.55.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-content-length": {
+      "version": "3.78.0",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-expect-continue": {
+      "version": "3.78.0",
+      "requires": {
+        "@aws-sdk/middleware-header-default": "3.78.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.78.0",
+      "requires": {
+        "@aws-crypto/crc32": "2.0.0",
+        "@aws-crypto/crc32c": "2.0.0",
+        "@aws-sdk/is-array-buffer": "3.55.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-header-default": {
+      "version": "3.78.0",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-host-header": {
+      "version": "3.78.0",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-location-constraint": {
+      "version": "3.78.0",
+      "requires": {
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-logger": {
+      "version": "3.78.0",
+      "requires": {
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-retry": {
+      "version": "3.80.0",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/service-error-classification": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-middleware": "3.78.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      }
+    },
+    "@aws-sdk/middleware-sdk-s3": {
+      "version": "3.78.0",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-arn-parser": "3.55.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-sdk-sts": {
+      "version": "3.78.0",
+      "requires": {
+        "@aws-sdk/middleware-signing": "3.78.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/signature-v4": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-serde": {
+      "version": "3.78.0",
+      "requires": {
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-signing": {
+      "version": "3.78.0",
+      "requires": {
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/signature-v4": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-ssec": {
+      "version": "3.78.0",
+      "requires": {
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-stack": {
+      "version": "3.78.0",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-user-agent": {
+      "version": "3.78.0",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/node-config-provider": {
+      "version": "3.80.0",
+      "requires": {
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/shared-ini-file-loader": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/node-http-handler": {
+      "version": "3.78.0",
+      "requires": {
+        "@aws-sdk/abort-controller": "3.78.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/querystring-builder": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/property-provider": {
+      "version": "3.78.0",
+      "requires": {
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/protocol-http": {
+      "version": "3.78.0",
+      "requires": {
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/querystring-builder": {
+      "version": "3.78.0",
+      "requires": {
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-uri-escape": "3.55.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/querystring-parser": {
+      "version": "3.78.0",
+      "requires": {
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/service-error-classification": {
+      "version": "3.78.0"
+    },
+    "@aws-sdk/shared-ini-file-loader": {
+      "version": "3.80.0",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/signature-v4": {
+      "version": "3.78.0",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.55.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-hex-encoding": "3.58.0",
+        "@aws-sdk/util-middleware": "3.78.0",
+        "@aws-sdk/util-uri-escape": "3.55.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/signature-v4-multi-region": {
+      "version": "3.78.0",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/signature-v4": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-arn-parser": "3.55.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/smithy-client": {
+      "version": "3.78.0",
+      "requires": {
+        "@aws-sdk/middleware-stack": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/types": {
+      "version": "3.78.0"
+    },
+    "@aws-sdk/url-parser": {
+      "version": "3.78.0",
+      "requires": {
+        "@aws-sdk/querystring-parser": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-arn-parser": {
+      "version": "3.55.0",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-base64-browser": {
+      "version": "3.58.0",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-base64-node": {
+      "version": "3.55.0",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.55.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-body-length-browser": {
+      "version": "3.55.0",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-body-length-node": {
+      "version": "3.55.0",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-buffer-from": {
+      "version": "3.55.0",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.55.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-config-provider": {
+      "version": "3.55.0",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.78.0",
+      "requires": {
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-defaults-mode-node": {
+      "version": "3.80.0",
+      "requires": {
+        "@aws-sdk/config-resolver": "3.80.0",
+        "@aws-sdk/credential-provider-imds": "3.80.0",
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-hex-encoding": {
+      "version": "3.58.0",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-locate-window": {
+      "version": "3.55.0",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-middleware": {
+      "version": "3.78.0",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-stream-browser": {
+      "version": "3.78.0",
+      "requires": {
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-stream-node": {
+      "version": "3.78.0",
+      "requires": {
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-uri-escape": {
+      "version": "3.55.0",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-user-agent-browser": {
+      "version": "3.78.0",
+      "requires": {
+        "@aws-sdk/types": "3.78.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-user-agent-node": {
+      "version": "3.80.0",
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-utf8-browser": {
+      "version": "3.55.0",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-utf8-node": {
+      "version": "3.55.0",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.55.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-waiter": {
+      "version": "3.78.0",
+      "requires": {
+        "@aws-sdk/abort-controller": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/xml-builder": {
+      "version": "3.55.0",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "bowser": {
+      "version": "2.11.0"
+    },
+    "entities": {
+      "version": "2.2.0"
+    },
+    "fast-xml-parser": {
+      "version": "3.19.0"
+    },
+    "tslib": {
+      "version": "2.4.0"
+    },
+    "uuid": {
+      "version": "8.3.2"
+    }
+  }
+}

--- a/scripts/dev-package-uploader/package.json
+++ b/scripts/dev-package-uploader/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "aws-3-uploader",
+  "version": "3.2.0",
+  "main": "publish-package.js",
+  "license": "MIT",
+  "private": true,
+  "dependencies": {
+    "@aws-sdk/client-s3": "^3.80.0"
+  }
+}

--- a/scripts/dev-package-uploader/publish-package.js
+++ b/scripts/dev-package-uploader/publish-package.js
@@ -35,7 +35,6 @@ try {
 }
 
 const fileStream = fs.readFileSync(TARBALL_PATH)
-console.log(`${BUCKET}/${FOLDER}/`)
 
 const s3Params = {
   Bucket: `${BUCKET}`, // The path to the directory you want to upload the object to, starting with your Space name.

--- a/scripts/dev-package-uploader/publish-package.js
+++ b/scripts/dev-package-uploader/publish-package.js
@@ -1,0 +1,33 @@
+const {PutObjectCommand, S3Client} = require('@aws-sdk/client-s3')
+const fs = require('fs')
+const path = require('path')
+
+const s3Client = new S3Client({
+  endpoint: 'https://fra1.digitaloceanspaces.com', // Find your endpoint in the control panel, under Settings. Prepend "https://".
+  region: 'fra1', // Must be "us-east-1" when creating new Spaces. Otherwise, use the region in your endpoint (e.g. nyc3).
+  credentials: {
+    accessKeyId: process.env.API_KEY, // Access key pair. You can create access key pairs using the control panel or API.
+    secretAccessKey: process.env.SECRET, // Secret access key defined through an environment variable.
+  },
+})
+
+const fileStream = fs.readFileSync(process.env.TARBALL_PATH)
+
+const s3Params = {
+  Bucket: process.env.BUCKET, // The path to the directory you want to upload the object to, starting with your Space name.
+  Key: path.basename(process.env.TARBALL_PATH), // Object key, referenced whenever you want to access this file later.
+  // Body: "Hello, World!", // The object's contents. This variable is an object, not a string.
+  ACL: 'public-read', // Defines ACL permissions, such as private or public.
+  Body: fileStream,
+}
+
+const uploadObject = async () => {
+  const data = await s3Client.send(new PutObjectCommand(s3Params))
+  console.log(
+    'Successfully uploaded object: ' + s3Params.Bucket + '/' + s3Params.Key,
+    `url: \x1b[33m\nhttps://packages.fulop.dev/${s3Params.Key}\n\x1b[0m`,
+  )
+  return data
+}
+
+uploadObject()

--- a/scripts/dev-package-uploader/publish-package.js
+++ b/scripts/dev-package-uploader/publish-package.js
@@ -1,3 +1,7 @@
+/**
+ * This script uploads a tarball to our Digital Ocean Space (S3-compatible object storage).
+ */
+
 const {PutObjectCommand, S3Client} = require('@aws-sdk/client-s3')
 const fs = require('fs')
 const path = require('path')
@@ -8,9 +12,6 @@ const REGION = process.env.DO_REGION
 const API_KEY = process.env.DO_API_KEY
 const SECRET = process.env.DO_SECRET
 const FOLDER = process.env.FOLDER
-// TODO: change the package naming to this:
-// `@theatre/core@0.4.8-insiders.HASH`
-// https://theatrejs-packages.nyc3.cdn.digitaloceanspaces.com/theatre-browser-bundles-3c6b62cc.tgz
 const DOMAIN =
   process.env.DO_DOMAIN || `${BUCKET}.${REGION}.cdn.digitaloceanspaces.com`
 

--- a/scripts/dev-package-uploader/publish-package.js
+++ b/scripts/dev-package-uploader/publish-package.js
@@ -2,6 +2,8 @@ const {PutObjectCommand, S3Client} = require('@aws-sdk/client-s3')
 const fs = require('fs')
 const path = require('path')
 
+const TARBALL_PATH = process.env.TARBALL_PATH
+
 const s3Client = new S3Client({
   endpoint: 'https://fra1.digitaloceanspaces.com', // Find your endpoint in the control panel, under Settings. Prepend "https://".
   region: 'fra1', // Must be "us-east-1" when creating new Spaces. Otherwise, use the region in your endpoint (e.g. nyc3).
@@ -11,11 +13,22 @@ const s3Client = new S3Client({
   },
 })
 
-const fileStream = fs.readFileSync(process.env.TARBALL_PATH)
+// Check if the tarball exists
+try {
+  fs.accessSync(TARBALL_PATH)
+} catch (error) {
+  if (error.code === 'ENOENT') {
+    throw new Error(`\x1b[31mFile does not exist: ${TARBALL_PATH}\x1b[0m`)
+  } else {
+    throw error
+  }
+}
+
+const fileStream = fs.readFileSync(TARBALL_PATH)
 
 const s3Params = {
   Bucket: process.env.BUCKET, // The path to the directory you want to upload the object to, starting with your Space name.
-  Key: path.basename(process.env.TARBALL_PATH), // Object key, referenced whenever you want to access this file later.
+  Key: path.basename(TARBALL_PATH), // Object key, referenced whenever you want to access this file later.
   // Body: "Hello, World!", // The object's contents. This variable is an object, not a string.
   ACL: 'public-read', // Defines ACL permissions, such as private or public.
   Body: fileStream,

--- a/scripts/generate-development-package-tarballs.mjs
+++ b/scripts/generate-development-package-tarballs.mjs
@@ -152,6 +152,12 @@ async function assignVersions(
 ; (async function() {
   process.env.THEATRE_IS_PUBLISHING = true
   const latestCommitHash = process.env.LATEST_COMMIT_HASH ? process.env.LATEST_COMMIT_HASH.slice(0, 8) : await $`git log -1 --pretty=format:%h`
+  console.log(process.env.LATEST_COMMIT_HASH)
+  console.log(await $`git log -1`)
+  console.log(await $`git remote get-url origin`)
+  throw new Error('stop here')
+
+
 
   const workspacesListString = await $`yarn workspaces list --json`
   const workspacesListObjects = workspacesListString.stdout

--- a/scripts/generate-development-package-tarballs.mjs
+++ b/scripts/generate-development-package-tarballs.mjs
@@ -163,7 +163,7 @@ async function assignVersions(
 
   await assignVersions(
     workspacesListObjects,
-    latestCommitHash.stdout,
+    latestCommitHash,
   )
 
   await Promise.all(

--- a/scripts/generate-development-package-tarballs.mjs
+++ b/scripts/generate-development-package-tarballs.mjs
@@ -64,7 +64,7 @@ async function assignVersions(
       fs.readFileSync(pathToPackage, {encoding: 'utf-8'}),
     )
 
-    const {version, dependencies, peerDependencies, devDependencies} = original
+    let {version, dependencies, peerDependencies, devDependencies} = original
     for (const deps of [dependencies, peerDependencies, devDependencies]) {
       if (!deps) continue
       for (let wpObject of workspacesListObjects) {
@@ -80,6 +80,7 @@ async function assignVersions(
         }
       }
     }
+    version = monorepoVersion
     const newJson = {
       ...original,
       version,
@@ -111,7 +112,7 @@ async function assignVersions(
   // TODO: replace the dependency versions with the commit hash in the packages
   await assignVersions(
     // TODO: don't use `0.4.8` for the package versions
-    `0.4.8-${latestCommitHash.stdout}`,
+    `0.4.8-dev-${latestCommitHash.stdout}`,
     workspacesListObjects,
     latestCommitHash.stdout,
   )

--- a/scripts/generate-development-package-tarballs.mjs
+++ b/scripts/generate-development-package-tarballs.mjs
@@ -1,0 +1,67 @@
+/**
+ * Generate tarballs from the theatre packages and publish them.
+ */
+
+import os from 'os'
+import path from 'path'
+
+const packagesToPack = [
+  '@theatre/core',
+  '@theatre/studio',
+  '@theatre/dataverse',
+  '@theatre/react',
+  '@theatre/browser-bundles',
+  '@theatre/r3f',
+]
+
+/**
+ * Generate the tarball for a workspace and publish it
+ *
+ * @param {string} workspace - Name of the workspace
+ * @param {string} latestCommitHash - Abbreviated hash of the latest commit
+ * @param {{location: string, name: string}[]} workspacesListObjects - Objects containing the paths to the workspaces
+ */
+async function generateAndPublishTarball(
+  workspace,
+  latestCommitHash,
+  workspacesListObjects,
+) {
+  const tarballName = `${workspace
+    // Get rid of the "@"
+    .slice(1)
+    // Replace the "/" with "-"
+    .replace('/', '-')}-${latestCommitHash}.tgz`
+  const pathToTarball = path.join(
+    __dirname,
+    '..',
+    workspacesListObjects.filter((wp) => {
+      return wp.name === workspace
+    })[0].location,
+    tarballName,
+  )
+  await $`yarn workspace ${workspace} pack --filename ${tarballName}`
+  await $`TARBALL_PATH=${pathToTarball} node scripts/dev-package-uploader/publish-package.js`
+}
+
+;(async function () {
+  process.env.THEATRE_IS_PUBLISHING = true
+  // TODO: Bump up the version `zx` to be able to use the `quiet()` function
+  // that prevents the output of the `git log` command to be printed to the terminal
+  const latestCommitHash = await $`git log -1 --pretty=format:%h`
+
+  const workspacesListString = await $`yarn workspaces list --json`
+  const workspacesListObjects = workspacesListString.stdout
+    .split(os.EOL)
+    .filter(Boolean)
+    .map((x) => JSON.parse(x))
+
+  await Promise.all(
+    packagesToPack.map((workspace) => {
+      generateAndPublishTarball(
+        workspace,
+        latestCommitHash,
+        workspacesListObjects,
+      )
+    }),
+  )
+})()

--- a/scripts/generate-development-package-tarballs.mjs
+++ b/scripts/generate-development-package-tarballs.mjs
@@ -49,7 +49,7 @@ async function generateAndPublishTarball(
   )
   console.log(tarballName, pathToTarball)
   await $`yarn workspace ${workspace} pack --filename ${tarballName}`
-  // await $`DO_TARBALL_PATH=${pathToTarball} node scripts/dev-package-uploader/publish-package.js`
+  await $`DO_TARBALL_PATH=${pathToTarball} node scripts/dev-package-uploader/publish-package.js`
 }
 
 /**

--- a/scripts/generate-development-package-tarballs.mjs
+++ b/scripts/generate-development-package-tarballs.mjs
@@ -40,7 +40,7 @@ async function generateAndPublishTarball(
     tarballName,
   )
   await $`yarn workspace ${workspace} pack --filename ${tarballName}`
-  await $`TARBALL_PATH=${pathToTarball} node scripts/dev-package-uploader/publish-package.js`
+  await $`DO_TARBALL_PATH=${pathToTarball} node scripts/dev-package-uploader/publish-package.js`
 }
 
 //TODO: add jsDoc/reuse the function from `./release.mjs` (that script must be refactored for this)

--- a/scripts/generate-development-package-tarballs.mjs
+++ b/scripts/generate-development-package-tarballs.mjs
@@ -151,7 +151,7 @@ async function assignVersions(
 
 ; (async function() {
   process.env.THEATRE_IS_PUBLISHING = true
-  const latestCommitHash = await $`git log -1 --pretty=format:%h`
+  const latestCommitHash = process.env.LATEST_COMMIT_HASH ? process.env.LATEST_COMMIT_HASH.slice(0, 8) : await $`git log -1 --pretty=format:%h`
 
   const workspacesListString = await $`yarn workspaces list --json`
   const workspacesListObjects = workspacesListString.stdout

--- a/scripts/generate-development-package-tarballs.mjs
+++ b/scripts/generate-development-package-tarballs.mjs
@@ -6,12 +6,12 @@ import os from 'os'
 import path from 'path'
 
 const packagesToPack = [
-  // '@theatre/core',
+  '@theatre/core',
   '@theatre/studio',
-  // '@theatre/dataverse',
-  // '@theatre/react',
-  // '@theatre/browser-bundles',
-  // '@theatre/r3f',
+  '@theatre/dataverse',
+  '@theatre/react',
+  '@theatre/browser-bundles',
+  '@theatre/r3f',
 ]
 
 /**
@@ -68,9 +68,7 @@ async function assignVersions(
     for (const deps of [dependencies, peerDependencies, devDependencies]) {
       if (!deps) continue
       for (let wpObject of workspacesListObjects) {
-        console.log(wpObject.name, deps[wpObject.name])
         if (deps[wpObject.name]) {
-          // console.log(wpObject.name, deps)
           // TODO: create a function for generating the tarball's name
           // and use it everywhere to avoid duplicating these lines
           const tarballName = `${wpObject.name
@@ -96,7 +94,6 @@ async function assignVersions(
     )
     await $`prettier --write ${packagePathRelativeFromRoot + '/package.json'}`
   }
-  throw new Error('stop')
 }
 
 ;(async function () {

--- a/scripts/generate-development-package-tarballs.mjs
+++ b/scripts/generate-development-package-tarballs.mjs
@@ -47,7 +47,6 @@ async function generateAndPublishTarball(
     })[0].location,
     tarballName,
   )
-  console.log(tarballName, pathToTarball)
   await $`yarn workspace ${workspace} pack --filename ${tarballName}`
   await $`DO_TARBALL_PATH=${pathToTarball} node scripts/dev-package-uploader/publish-package.js`
 }
@@ -151,13 +150,10 @@ async function assignVersions(
 
 ; (async function() {
   process.env.THEATRE_IS_PUBLISHING = true
-  const latestCommitHash = process.env.LATEST_COMMIT_HASH ? process.env.LATEST_COMMIT_HASH.slice(0, 8) : await $`git log -1 --pretty=format:%h`
-  console.log(process.env.LATEST_COMMIT_HASH)
-  console.log(await $`git log -1`)
-  console.log(await $`git remote get-url origin`)
-  throw new Error('stop here')
-
-
+  // In the CI `git log -1` points to a fake merge commit,
+  // so we have to use the value of a special GitHub context variable
+  // through the `LATEST_COMMIT_HASH` environmental variable.
+  const latestCommitHash = process.env.LATEST_COMMIT_HASH.slice(0, 8)
 
   const workspacesListString = await $`yarn workspaces list --json`
   const workspacesListObjects = workspacesListString.stdout


### PR DESCRIPTION
# Description

> :warning: We decided to test publishing the dev packages to npm instead of an object storage. This PR is likely to be closed without being merged!

This PR adds a script that generates tarballs from the `@theatre` packages and publishes them in the CI. [See this  (private) Notion doc](https://www.notion.so/theatrejs/POC-Publishing-development-packages-2e282feb3e85408aac9738eeb0a53e72) for the behind-the-scenes information.

# Versioning of the dev packages
A CI job builds the packages and assigns them a version number based on the version (without tags like `-dev.3`) specified in the root `package.json` (or `packages/r3f/package.json` in the case of `r3f` since that has an independent release schedule) and the abbreviated hash of the latest commit. Here's an example:
| prop | value |
| --- | --- |
| package name | `@theatre/core` |
| root version | `0.4.8-dev.3` |
| latest commit hash | `c8884093` |
| dev package version | `0.4.8-insiders.c8884093` |
| url (the domain will change to `packages.theatrejs.com`, or something similiar in the future) | `https://theatrejs-packages.nyc3.cdn.digitaloceanspaces.com/@theatre/core-c8884093.tgz` |
| install command | `yarn add https://theatrejs-packages.nyc3.cdn.digitaloceanspaces.com/@theatre/core-c8884093.tgz` 

# Testing this PR

1. Clone this repo: https://github.com/fulopkovacs/theatre-r3f-create-react-app
```
git clone git@github.com:fulopkovacs/theatre-r3f-create-react-app.git
```
2. Run the following commands in the repo (the second command takes quite a while):
```
yarn && yarn start
```
3. Visit `http://localhost:3000` in the browser
_Optional_:  You can verify that you're using the dev packages by checking the version of the `@theatre` packages with `yarn why <package-name>`, like:
```
$ yarn why @theatre/core
yarn why v1.22.10
[1/4] Why do we have the module "@theatre/core"...?
[2/4] Initialising dependency graph...
[3/4] Finding dependency...
[4/4] Calculating file sizes...
=> Found "@theatre/core@0.4.8-insiders.c8884093"
info Has been hoisted to "@theatre/core"
info This module exists because it's specified in "dependencies".
info Disk size without dependencies: "656KB"
info Disk size with unique dependencies: "1.13MB"
info Disk size with transitive dependencies: "3.73MB"
info Number of shared dependencies: 2
Done in 0.42s.
```

This project wouldn't get built with the newest _published_ versions of the `@theatre` packages: you can try it in the same repo on the `broken` branch.

# :warning:  Limitations
CodeSandbox doesn't seem to support loading tarballs from urls:
- issue: https://github.com/codesandbox/codesandbox-client/issues/1570
- example for the error we get with CodeSandbox: [link](https://codesandbox.io/s/crazy-fire-6zro0w?file=/package.json:502-586)
 

# TODO
- [x] there's something weird around the commit hash in the CI (for some reason `git log -1` returns a different commit than the last one of this branch, so I'm guessing I have to use the env var provided by GH (`GITHUB_SHA`, [docs](https://docs.github.com/en/enterprise-server@3.4/actions/learn-github-actions/environment-variables#default-environment-variables)))
- [ ] (optional) check if publishing the dev packages can be extracted into a separate job (it would make our CI cleaner)
