### PR TITLE
Chore/cl 2022 05/refactor and docs from inline editing feature

### DIFF
--- a/packages/dataverse/src/Atom.ts
+++ b/packages/dataverse/src/Atom.ts
@@ -25,6 +25,8 @@ enum ValueTypes {
 export interface IdentityDerivationProvider {
   /**
    * @internal
+   * Future: We could consider using a `Symbol.for("dataverse/IdentityDerivationProvider")` as a key here, similar to
+   * how {@link Iterable} works for `of`.
    */
   readonly $$isIdentityDerivationProvider: true
   /**

--- a/packages/dataverse/src/pointer.typeTest.ts
+++ b/packages/dataverse/src/pointer.typeTest.ts
@@ -1,0 +1,106 @@
+import type {Pointer, UnindexablePointer} from './pointer'
+import type {$IntentionalAny} from './types'
+
+const nominal = Symbol()
+type Nominal<Name> = string & {[nominal]: Name}
+
+type Key = Nominal<'key'>
+type Id = Nominal<'id'>
+
+type IdObject = {
+  inner: true
+}
+
+type KeyObject = {
+  inner: {
+    byIds: Partial<Record<Id, IdObject>>
+  }
+}
+
+type NestedNominalThing = {
+  optional?: true
+  byKeys: Partial<Record<Key, KeyObject>>
+}
+
+interface TypeError<M> {}
+
+type Debug<T extends 0> = T
+type IsTrue<T extends true> = T
+type IsFalse<F extends false> = F
+type IsExtends<F, R extends F> = F
+type IsExactly<F, R extends F> = F extends R
+  ? true
+  : TypeError<[F, 'does not extend', R]>
+
+function test() {
+  const p = todo<Pointer<NestedNominalThing>>()
+  const key1 = todo<Key>()
+  const id1 = todo<Id>()
+
+  type A = UnindexablePointer[typeof key1]
+  type BaseChecks = [
+    IsExtends<any, any>,
+    IsExtends<undefined | 1, undefined>,
+    IsExtends<string, Key>,
+    IsTrue<IsExactly<UnindexablePointer[typeof key1], Pointer<undefined>>>,
+    IsTrue<
+      IsExactly<Pointer<undefined | true>['...']['...'], Pointer<undefined>>
+    >,
+    IsTrue<
+      IsExactly<
+        Pointer<Record<Key, true | undefined>>[Key],
+        Pointer<true | undefined>
+      >
+    >,
+    IsTrue<IsExactly<Pointer<undefined>[Key], Pointer<undefined>>>,
+    // Debug<Pointer<undefined | Record<string, true>>[Key]>,
+    IsTrue<IsExactly<Pointer<Record<string, true>>[string], Pointer<true>>>,
+    IsTrue<
+      IsExactly<
+        Pointer<undefined | Record<string, true>>[string],
+        Pointer<true | undefined>
+      >
+    >,
+    IsTrue<
+      IsExactly<
+        Pointer<undefined | Record<Key, true>>[Key],
+        Pointer<true | undefined>
+      >
+    >,
+    // Debug<Pointer<undefined | true>['...']['...']>,
+    // IsFalse<any extends Pointer<undefined | true> ? true : false>,
+    // what extends what
+    IsTrue<1 & undefined extends undefined ? true : false>,
+    IsFalse<1 | undefined extends undefined ? true : false>,
+  ]
+
+  t<Pointer<undefined | true>>() //
+    .isExactly(p.optional).ok
+
+  t<Pointer<undefined | KeyObject>>() //
+    .isExactly(p.byKeys[key1]).ok
+
+  t<Pointer<undefined | KeyObject['inner']>>() //
+    .isExactly(p.byKeys[key1].inner).ok
+
+  t<Pointer<undefined | IdObject>>() //
+    .isExactly(p.byKeys[key1].inner.byIds[id1]).ok
+
+  p.byKeys[key1]
+}
+
+function todo<T>(hmm?: TemplateStringsArray): T {
+  return null as $IntentionalAny
+}
+function t<T>(): {
+  isExactly<R extends T>(
+    hmm: R,
+  ): T extends R
+    ? // any extends R
+      //   ? TypeError<[R, 'is any']>
+      //   :
+      {ok: true}
+    : TypeError<[T, 'does not extend', R]>
+} {
+  return {isExactly: (hmm) => hmm as $IntentionalAny}
+}

--- a/packages/r3f/src/editableFactoryConfigUtils.ts
+++ b/packages/r3f/src/editableFactoryConfigUtils.ts
@@ -1,4 +1,4 @@
-import type {IShorthandCompoundProps} from '@theatre/core'
+import type {UnknownShorthandCompoundProps} from '@theatre/core'
 import {types} from '@theatre/core'
 import type {Object3D} from 'three'
 import type {IconID} from './icons'
@@ -9,7 +9,7 @@ export type Helper = Object3D & {
 type PropConfig<T> = {
   parse: (props: Record<string, any>) => T
   apply: (value: T, object: any) => void
-  type: IShorthandCompoundProps
+  type: UnknownShorthandCompoundProps
 }
 type Props = Record<string, PropConfig<any>>
 type Meta<T> = {

--- a/theatre/core/src/coreExports.ts
+++ b/theatre/core/src/coreExports.ts
@@ -16,6 +16,7 @@ import {isPointer} from '@theatre/dataverse'
 import {isDerivation, valueDerivation} from '@theatre/dataverse'
 import type {$IntentionalAny, VoidFn} from '@theatre/shared/utils/types'
 import coreTicker from './coreTicker'
+import type {ProjectId} from '@theatre/shared/utils/ids'
 export {types}
 
 /**
@@ -45,7 +46,7 @@ export {types}
  */
 export function getProject(id: string, config: IProjectConfig = {}): IProject {
   const {...restOfConfig} = config
-  const existingProject = projectsSingleton.get(id)
+  const existingProject = projectsSingleton.get(id as ProjectId)
   if (existingProject) {
     if (process.env.NODE_ENV !== 'production') {
       if (!deepEqual(config, existingProject.config)) {
@@ -67,9 +68,9 @@ export function getProject(id: string, config: IProjectConfig = {}): IProject {
 
   if (config.state) {
     if (process.env.NODE_ENV !== 'production') {
-      shallowValidateOnDiskState(id, config.state)
+      shallowValidateOnDiskState(id as ProjectId, config.state)
     } else {
-      deepValidateOnDiskState(id, config.state)
+      deepValidateOnDiskState(id as ProjectId, config.state)
     }
   }
 
@@ -80,7 +81,7 @@ export function getProject(id: string, config: IProjectConfig = {}): IProject {
  * Lightweight validator that only makes sure the state's definitionVersion is correct.
  * Does not do a thorough validation of the state.
  */
-const shallowValidateOnDiskState = (projectId: string, s: OnDiskState) => {
+const shallowValidateOnDiskState = (projectId: ProjectId, s: OnDiskState) => {
   if (
     Array.isArray(s) ||
     s == null ||
@@ -94,7 +95,7 @@ const shallowValidateOnDiskState = (projectId: string, s: OnDiskState) => {
   }
 }
 
-const deepValidateOnDiskState = (projectId: string, s: OnDiskState) => {
+const deepValidateOnDiskState = (projectId: ProjectId, s: OnDiskState) => {
   shallowValidateOnDiskState(projectId, s)
   // @TODO do a deep validation here
 }

--- a/theatre/core/src/index.ts
+++ b/theatre/core/src/index.ts
@@ -12,7 +12,7 @@ export type {
 export type {ISequence} from '@theatre/core/sequences/TheatreSequence'
 export type {ISheetObject} from '@theatre/core/sheetObjects/TheatreSheetObject'
 export type {ISheet} from '@theatre/core/sheets/TheatreSheet'
-export type {IShorthandCompoundProps} from '@theatre/core/propTypes'
+export type {UnknownShorthandCompoundProps} from '@theatre/core/propTypes'
 import * as globalVariableNames from '@theatre/shared/globalVariableNames'
 import type StudioBundle from '@theatre/studio/StudioBundle'
 import CoreBundle from './CoreBundle'

--- a/theatre/core/src/privateAPIs.ts
+++ b/theatre/core/src/privateAPIs.ts
@@ -6,13 +6,12 @@ import type SheetObject from '@theatre/core/sheetObjects/SheetObject'
 import type {ISheetObject} from '@theatre/core/sheetObjects/TheatreSheetObject'
 import type Sheet from '@theatre/core/sheets/Sheet'
 import type {ISheet} from '@theatre/core/sheets/TheatreSheet'
+import type {UnknownShorthandCompoundProps} from './propTypes/internals'
 import type {$IntentionalAny} from '@theatre/shared/utils/types'
 
 const publicAPIToPrivateAPIMap = new WeakMap()
 
-export function privateAPI<
-  P extends IProject | ISheet | ISheetObject<$IntentionalAny> | ISequence,
->(
+export function privateAPI<P extends {type: string}>(
   pub: P,
 ): P extends IProject
   ? Project
@@ -29,8 +28,8 @@ export function privateAPI<
 export function setPrivateAPI(pub: IProject, priv: Project): void
 export function setPrivateAPI(pub: ISheet, priv: Sheet): void
 export function setPrivateAPI(pub: ISequence, priv: Sequence): void
-export function setPrivateAPI(
-  pub: ISheetObject<$IntentionalAny>,
+export function setPrivateAPI<Props extends UnknownShorthandCompoundProps>(
+  pub: ISheetObject<Props>,
   priv: SheetObject,
 ): void
 export function setPrivateAPI(pub: {}, priv: {}): void {

--- a/theatre/core/src/projects/Project.ts
+++ b/theatre/core/src/projects/Project.ts
@@ -13,6 +13,11 @@ import type {ProjectState} from './store/storeTypes'
 import type {Deferred} from '@theatre/shared/utils/defer'
 import {defer} from '@theatre/shared/utils/defer'
 import globals from '@theatre/shared/globals'
+import type {
+  ProjectId,
+  SheetId,
+  SheetInstanceId,
+} from '@theatre/shared/utils/ids'
 
 export type Conf = Partial<{
   state: OnDiskState
@@ -44,7 +49,7 @@ export default class Project {
   type: 'Theatre_Project' = 'Theatre_Project'
 
   constructor(
-    id: string,
+    id: ProjectId,
     readonly config: Conf = {},
     readonly publicApi: TheatreProject,
   ) {
@@ -150,7 +155,10 @@ export default class Project {
     return this._readyDeferred.status === 'resolved'
   }
 
-  getOrCreateSheet(sheetId: string, instanceId: string = 'default'): Sheet {
+  getOrCreateSheet(
+    sheetId: SheetId,
+    instanceId: SheetInstanceId = 'default' as SheetInstanceId,
+  ): Sheet {
     let template = this._sheetTemplates.getState()[sheetId]
 
     if (!template) {

--- a/theatre/core/src/projects/TheatreProject.ts
+++ b/theatre/core/src/projects/TheatreProject.ts
@@ -2,6 +2,11 @@ import {privateAPI, setPrivateAPI} from '@theatre/core/privateAPIs'
 import Project from '@theatre/core/projects/Project'
 import type {ISheet} from '@theatre/core/sheets/TheatreSheet'
 import type {ProjectAddress} from '@theatre/shared/utils/addresses'
+import type {
+  ProjectId,
+  SheetId,
+  SheetInstanceId,
+} from '@theatre/shared/utils/ids'
 import {validateInstanceId} from '@theatre/shared/utils/sanitizers'
 import {validateAndSanitiseSlashedPathOrThrow} from '@theatre/shared/utils/slashedPaths'
 import type {$IntentionalAny} from '@theatre/shared/utils/types'
@@ -58,7 +63,7 @@ export default class TheatreProject implements IProject {
    * @internal
    */
   constructor(id: string, config: IProjectConfig = {}) {
-    setPrivateAPI(this, new Project(id, config, this))
+    setPrivateAPI(this, new Project(id as ProjectId, config, this))
   }
 
   get ready(): Promise<void> {
@@ -87,7 +92,9 @@ export default class TheatreProject implements IProject {
       )
     }
 
-    return privateAPI(this).getOrCreateSheet(sanitizedPath, instanceId)
-      .publicApi
+    return privateAPI(this).getOrCreateSheet(
+      sanitizedPath as SheetId,
+      instanceId as SheetInstanceId,
+    ).publicApi
   }
 }

--- a/theatre/core/src/projects/projectsSingleton.ts
+++ b/theatre/core/src/projects/projectsSingleton.ts
@@ -1,8 +1,9 @@
 import {Atom} from '@theatre/dataverse'
+import type {ProjectId} from '@theatre/shared/utils/ids'
 import type Project from './Project'
 
 interface State {
-  projects: Record<string, Project>
+  projects: Record<ProjectId, Project>
 }
 
 class ProjectsSingleton {
@@ -12,15 +13,15 @@ class ProjectsSingleton {
   /**
    * We're trusting here that each project id is unique
    */
-  add(id: string, project: Project) {
+  add(id: ProjectId, project: Project) {
     this.atom.reduceState(['projects', id], () => project)
   }
 
-  get(id: string): Project | undefined {
+  get(id: ProjectId): Project | undefined {
     return this.atom.getState().projects[id]
   }
 
-  has(id: string) {
+  has(id: ProjectId) {
     return !!this.get(id)
   }
 }

--- a/theatre/core/src/projects/store/storeTypes.ts
+++ b/theatre/core/src/projects/store/storeTypes.ts
@@ -1,3 +1,4 @@
+import type {SheetId} from '@theatre/shared/utils/ids'
 import type {StrictRecord} from '@theatre/shared/utils/types'
 import type {SheetState_Historic} from './types/SheetState_Historic'
 
@@ -31,7 +32,7 @@ export interface ProjectEphemeralState {
  * at {@link StudioHistoricState.coreByProject}
  */
 export interface ProjectState_Historic {
-  sheetsById: StrictRecord<string, SheetState_Historic>
+  sheetsById: StrictRecord<SheetId, SheetState_Historic>
   /**
    * The last 50 revision IDs this state is based on, starting with the most recent one.
    * The most recent one is the revision ID of this state

--- a/theatre/core/src/projects/store/types/SheetState_Historic.ts
+++ b/theatre/core/src/projects/store/types/SheetState_Historic.ts
@@ -1,5 +1,13 @@
-import type {KeyframeId, SequenceTrackId} from '@theatre/shared/utils/ids'
-import type {SerializableMap, StrictRecord} from '@theatre/shared/utils/types'
+import type {
+  KeyframeId,
+  ObjectAddressKey,
+  SequenceTrackId,
+} from '@theatre/shared/utils/ids'
+import type {
+  SerializableMap,
+  SerializableValue,
+  StrictRecord,
+} from '@theatre/shared/utils/types'
 
 export interface SheetState_Historic {
   /**
@@ -10,14 +18,13 @@ export interface SheetState_Historic {
    * of another state, it will be able to inherit the overrides from ancestor states.
    */
   staticOverrides: {
-    byObject: StrictRecord<string, SerializableMap>
+    byObject: StrictRecord<ObjectAddressKey, SerializableMap>
   }
-  sequence?: Sequence
+  sequence?: HistoricPositionalSequence
 }
 
-type Sequence = PositionalSequence
-
-type PositionalSequence = {
+// Question: What is this? The timeline position of a sequence?
+export type HistoricPositionalSequence = {
   type: 'PositionalSequence'
   length: number
   /**
@@ -27,7 +34,7 @@ type PositionalSequence = {
   subUnitsPerUnit: number
 
   tracksByObject: StrictRecord<
-    string,
+    ObjectAddressKey,
     {
       trackIdByPropPath: StrictRecord<string, SequenceTrackId>
       trackData: StrictRecord<SequenceTrackId, TrackData>
@@ -39,7 +46,10 @@ export type TrackData = BasicKeyframedTrack
 
 export type Keyframe = {
   id: KeyframeId
-  value: unknown
+  /** The `value` is the raw value type such as `Rgba` or `number`. See {@link SerializableValue} */
+  // Future: is there another layer that we may need to be able to store older values on the
+  // case of a prop config change? As keyframes can technically have their propConfig changed.
+  value: SerializableValue
   position: number
   handles: [leftX: number, leftY: number, rightX: number, rightY: number]
   connectedRight: boolean
@@ -47,5 +57,9 @@ export type Keyframe = {
 
 export type BasicKeyframedTrack = {
   type: 'BasicKeyframedTrack'
+  /**
+   * {@link Keyframe} is not provided an explicit generic value `T`, because
+   * a single track can technically have multiple different types for each keyframe.
+   */
   keyframes: Keyframe[]
 }

--- a/theatre/core/src/propTypes/index.ts
+++ b/theatre/core/src/propTypes/index.ts
@@ -10,8 +10,8 @@ import {
 } from '@theatre/shared/utils/color'
 import {clamp, mapValues} from 'lodash-es'
 import type {
-  IShorthandCompoundProps,
-  IValidCompoundProps,
+  UnknownShorthandCompoundProps,
+  UnknownValidCompoundProps,
   ShorthandCompoundPropsToLonghandCompoundProps,
 } from './internals'
 import {propTypeSymbol, sanitizeCompoundProps} from './internals'
@@ -88,7 +88,7 @@ const validateCommonOpts = (fnCallSignature: string, opts?: CommonOpts) => {
  * ```
  *
  */
-export const compound = <Props extends IShorthandCompoundProps>(
+export const compound = <Props extends UnknownShorthandCompoundProps>(
   props: Props,
   opts: CommonOpts = {},
 ): PropTypeConfig_Compound<
@@ -101,7 +101,7 @@ export const compound = <Props extends IShorthandCompoundProps>(
     ShorthandCompoundPropsToLonghandCompoundProps<Props>
   > = {
     type: 'compound',
-    props: sanitizedProps,
+    props: sanitizedProps as $IntentionalAny,
     valueType: null as $IntentionalAny,
     [propTypeSymbol]: 'TheatrePropType',
     label: opts.label,
@@ -690,7 +690,7 @@ export interface PropTypeConfig_StringLiteral<T extends string>
 
 export interface PropTypeConfig_Rgba extends ISimplePropType<'rgba', Rgba> {}
 
-type DeepPartialCompound<Props extends IValidCompoundProps> = {
+type DeepPartialCompound<Props extends UnknownValidCompoundProps> = {
   [K in keyof Props]?: DeepPartial<Props[K]>
 }
 
@@ -701,13 +701,14 @@ type DeepPartial<Conf extends PropTypeConfig> =
     ? DeepPartialCompound<T>
     : never
 
-export interface PropTypeConfig_Compound<Props extends IValidCompoundProps>
-  extends IBasePropType<
+export interface PropTypeConfig_Compound<
+  Props extends UnknownValidCompoundProps,
+> extends IBasePropType<
     'compound',
     {[K in keyof Props]: Props[K]['valueType']},
     DeepPartialCompound<Props>
   > {
-  props: Record<string, PropTypeConfig>
+  props: Record<keyof Props, PropTypeConfig>
 }
 
 export interface PropTypeConfig_Enum extends IBasePropType<'enum', {}> {

--- a/theatre/core/src/propTypes/index.ts
+++ b/theatre/core/src/propTypes/index.ts
@@ -728,4 +728,4 @@ export type PropTypeConfig =
   | PropTypeConfig_Compound<$IntentionalAny>
   | PropTypeConfig_Enum
 
-export type {IShorthandCompoundProps}
+export type {UnknownShorthandCompoundProps}

--- a/theatre/core/src/sequences/interpolationTripleAtPosition.ts
+++ b/theatre/core/src/sequences/interpolationTripleAtPosition.ts
@@ -6,11 +6,15 @@ import type {
 import type {IDerivation, Pointer} from '@theatre/dataverse'
 import {ConstantDerivation, prism, val} from '@theatre/dataverse'
 import logger from '@theatre/shared/logger'
+import type {SerializableValue} from '@theatre/shared/utils/types'
 import UnitBezier from 'timing-function/lib/UnitBezier'
 
+/** `left` and `right` are not necessarily the same type.  */
 export type InterpolationTriple = {
-  left: unknown
-  right?: unknown
+  /** `left` and `right` are not necessarily the same type.  */
+  left: SerializableValue
+  /** `left` and `right` are not necessarily the same type.  */
+  right?: SerializableValue
   progression: number
 }
 
@@ -75,10 +79,10 @@ function _forKeyframedTrack(
 
 const undefinedConstD = new ConstantDerivation(undefined)
 
-const updateState = (
+function updateState(
   progressionD: IDerivation<number>,
   track: BasicKeyframedTrack,
-): IStartedState => {
+): IStartedState {
   const progression = progressionD.getValue()
   if (track.keyframes.length === 0) {
     return {

--- a/theatre/core/src/sheetObjects/SheetObject.test.ts
+++ b/theatre/core/src/sheetObjects/SheetObject.test.ts
@@ -4,18 +4,19 @@
 import {setupTestSheet} from '@theatre/shared/testUtils'
 import {encodePathToProp} from '@theatre/shared/utils/addresses'
 import {asKeyframeId, asSequenceTrackId} from '@theatre/shared/utils/ids'
+import type {ObjectAddressKey, SequenceTrackId} from '@theatre/shared/utils/ids'
 import {iterateOver, prism} from '@theatre/dataverse'
 import type {SheetState_Historic} from '@theatre/core/projects/store/types/SheetState_Historic'
 
 describe(`SheetObject`, () => {
   describe('static overrides', () => {
     const setup = async (
-      staticOverrides: SheetState_Historic['staticOverrides']['byObject'][string] = {},
+      staticOverrides: SheetState_Historic['staticOverrides']['byObject'][ObjectAddressKey] = {},
     ) => {
       const {studio, objPublicAPI} = await setupTestSheet({
         staticOverrides: {
           byObject: {
-            obj: staticOverrides,
+            ['obj' as ObjectAddressKey]: staticOverrides,
           },
         },
       })
@@ -260,12 +261,12 @@ describe(`SheetObject`, () => {
           length: 20,
           subUnitsPerUnit: 30,
           tracksByObject: {
-            obj: {
+            ['obj' as ObjectAddressKey]: {
               trackIdByPropPath: {
                 [encodePathToProp(['position', 'y'])]: asSequenceTrackId('1'),
               },
               trackData: {
-                '1': {
+                ['1' as SequenceTrackId]: {
                   type: 'BasicKeyframedTrack',
                   keyframes: [
                     {

--- a/theatre/core/src/sheetObjects/SheetObject.ts
+++ b/theatre/core/src/sheetObjects/SheetObject.ts
@@ -108,11 +108,13 @@ export default class SheetObject implements IdentityDerivationProvider {
     )
   }
 
-  getValueByPointer(pointer: SheetObject['propsP']): SerializableValue {
+  getValueByPointer<T extends SerializableValue>(pointer: Pointer<T>): T {
     const allValuesP = val(this.getValues())
     const {path} = getPointerParts(pointer)
 
-    return val(pointerDeep(allValuesP as $FixMe, path)) as SerializableMap
+    return val(
+      pointerDeep(allValuesP as $FixMe, path),
+    ) as SerializableValue as T
   }
 
   getIdentityDerivation(path: Array<string | number>): IDerivation<unknown> {

--- a/theatre/core/src/sheetObjects/SheetObjectTemplate.test.ts
+++ b/theatre/core/src/sheetObjects/SheetObjectTemplate.test.ts
@@ -4,6 +4,7 @@
 import {setupTestSheet} from '@theatre/shared/testUtils'
 import {encodePathToProp} from '@theatre/shared/utils/addresses'
 import {asSequenceTrackId} from '@theatre/shared/utils/ids'
+import type {ObjectAddressKey, SequenceTrackId} from '@theatre/shared/utils/ids'
 import type {$IntentionalAny} from '@theatre/shared/utils/types'
 import {iterateOver} from '@theatre/dataverse'
 
@@ -19,15 +20,15 @@ describe(`SheetObjectTemplate`, () => {
           subUnitsPerUnit: 30,
           length: 10,
           tracksByObject: {
-            obj: {
+            ['obj' as ObjectAddressKey]: {
               trackIdByPropPath: {
                 [encodePathToProp(['position', 'x'])]: asSequenceTrackId('x'),
                 [encodePathToProp(['position', 'invalid'])]:
                   asSequenceTrackId('invalidTrack'),
               },
               trackData: {
-                x: null as $IntentionalAny,
-                invalid: null as $IntentionalAny,
+                ['x' as SequenceTrackId]: null as $IntentionalAny,
+                ['invalid' as SequenceTrackId]: null as $IntentionalAny,
               },
             },
           },
@@ -74,15 +75,15 @@ describe(`SheetObjectTemplate`, () => {
           subUnitsPerUnit: 30,
           length: 10,
           tracksByObject: {
-            obj: {
+            ['obj' as ObjectAddressKey]: {
               trackIdByPropPath: {
                 [encodePathToProp(['position', 'x'])]: asSequenceTrackId('x'),
                 [encodePathToProp(['position', 'invalid'])]:
                   asSequenceTrackId('invalidTrack'),
               },
               trackData: {
-                x: null as $IntentionalAny,
-                invalid: null as $IntentionalAny,
+                ['x' as SequenceTrackId]: null as $IntentionalAny,
+                ['invalid' as SequenceTrackId]: null as $IntentionalAny,
               },
             },
           },

--- a/theatre/core/src/sheetObjects/SheetObjectTemplate.ts
+++ b/theatre/core/src/sheetObjects/SheetObjectTemplate.ts
@@ -1,7 +1,7 @@
 import type Project from '@theatre/core/projects/Project'
 import type Sheet from '@theatre/core/sheets/Sheet'
 import type SheetTemplate from '@theatre/core/sheets/SheetTemplate'
-import type {SheetObjectConfig} from '@theatre/core/sheets/TheatreSheet'
+import type {SheetObjectPropTypeConfig} from '@theatre/core/sheets/TheatreSheet'
 import {emptyArray} from '@theatre/shared/utils'
 import type {
   PathToProp,
@@ -9,7 +9,7 @@ import type {
   WithoutSheetInstance,
 } from '@theatre/shared/utils/addresses'
 import getDeep from '@theatre/shared/utils/getDeep'
-import type {SequenceTrackId} from '@theatre/shared/utils/ids'
+import type {ObjectAddressKey, SequenceTrackId} from '@theatre/shared/utils/ids'
 import SimpleCache from '@theatre/shared/utils/SimpleCache'
 import type {
   $FixMe,
@@ -23,7 +23,6 @@ import set from 'lodash-es/set'
 import getPropDefaultsOfSheetObject from './getPropDefaultsOfSheetObject'
 import SheetObject from './SheetObject'
 import logger from '@theatre/shared/logger'
-import type {PropTypeConfig_Compound} from '@theatre/core/propTypes'
 import {
   getPropConfigByPath,
   isPropConfSequencable,
@@ -34,12 +33,15 @@ export type IPropPathToTrackIdTree = {
   [key in string]?: SequenceTrackId | IPropPathToTrackIdTree
 }
 
+/**
+ * TODO: Add documentation, and share examples of sheet objects.
+ *
+ * See {@link SheetObject} for more information.
+ */
 export default class SheetObjectTemplate {
   readonly address: WithoutSheetInstance<SheetObjectAddress>
   readonly type: 'Theatre_SheetObjectTemplate' = 'Theatre_SheetObjectTemplate'
-  protected _config: Atom<
-    SheetObjectConfig<PropTypeConfig_Compound<$IntentionalAny>>
-  >
+  protected _config: Atom<SheetObjectPropTypeConfig>
   readonly _cache = new SimpleCache()
   readonly project: Project
 
@@ -49,9 +51,9 @@ export default class SheetObjectTemplate {
 
   constructor(
     readonly sheetTemplate: SheetTemplate,
-    objectKey: string,
+    objectKey: ObjectAddressKey,
     nativeObject: unknown,
-    config: SheetObjectConfig<$IntentionalAny>,
+    config: SheetObjectPropTypeConfig,
   ) {
     this.address = {...sheetTemplate.address, objectKey}
     this._config = new Atom(config)
@@ -61,13 +63,13 @@ export default class SheetObjectTemplate {
   createInstance(
     sheet: Sheet,
     nativeObject: unknown,
-    config: SheetObjectConfig<$IntentionalAny>,
+    config: SheetObjectPropTypeConfig,
   ): SheetObject {
     this._config.setState(config)
     return new SheetObject(sheet, this, nativeObject)
   }
 
-  overrideConfig(config: SheetObjectConfig<$IntentionalAny>) {
+  overrideConfig(config: SheetObjectPropTypeConfig) {
     this._config.setState(config)
   }
 
@@ -99,7 +101,7 @@ export default class SheetObjectTemplate {
             pointerToSheetState.staticOverrides.byObject[
               this.address.objectKey
             ],
-          ) || {}
+          ) ?? {}
 
         const config = val(this._config.pointer)
         const deserialized = config.deserializeAndSanitize(json) || {}

--- a/theatre/core/src/sheetObjects/getPropDefaultsOfSheetObject.ts
+++ b/theatre/core/src/sheetObjects/getPropDefaultsOfSheetObject.ts
@@ -1,7 +1,6 @@
-import type {SheetObjectConfig} from '@theatre/core/sheets/TheatreSheet'
+import type {SheetObjectPropTypeConfig} from '@theatre/core/sheets/TheatreSheet'
 import type {
   $FixMe,
-  $IntentionalAny,
   SerializableMap,
   SerializableValue,
 } from '@theatre/shared/utils/types'
@@ -17,9 +16,9 @@ const cachedDefaults = new WeakMap<PropTypeConfig, SerializableValue>()
  * Generates and caches a default value for the config of a SheetObject.
  */
 export default function getPropDefaultsOfSheetObject(
-  config: SheetObjectConfig<$IntentionalAny>,
+  config: SheetObjectPropTypeConfig,
 ): SerializableMap {
-  return getDefaultsOfPropTypeConfig(config) as $IntentionalAny
+  return getDefaultsOfPropTypeConfig(config) as SerializableMap // sheet objects result in non-primitive objects
 }
 
 function getDefaultsOfPropTypeConfig(

--- a/theatre/core/src/sheets/SheetTemplate.ts
+++ b/theatre/core/src/sheets/SheetTemplate.ts
@@ -4,27 +4,38 @@ import type {
   SheetAddress,
   WithoutSheetInstance,
 } from '@theatre/shared/utils/addresses'
-import type {$IntentionalAny} from '@theatre/shared/utils/types'
 import {Atom} from '@theatre/dataverse'
+import type {Pointer} from '@theatre/dataverse'
 import Sheet from './Sheet'
-import type {SheetObjectConfig} from './TheatreSheet'
+import type {ObjectNativeObject} from './Sheet'
+import type {SheetObjectPropTypeConfig} from './TheatreSheet'
+import type {
+  ObjectAddressKey,
+  SheetId,
+  SheetInstanceId,
+} from '@theatre/shared/utils/ids'
+import type {StrictRecord} from '@theatre/shared/utils/types'
+
+type SheetTemplateObjectTemplateMap = StrictRecord<
+  ObjectAddressKey,
+  SheetObjectTemplate
+>
 
 export default class SheetTemplate {
   readonly type: 'Theatre_SheetTemplate' = 'Theatre_SheetTemplate'
   readonly address: WithoutSheetInstance<SheetAddress>
-  private _instances = new Atom<{[instanceId: string]: Sheet}>({})
-  readonly instancesP = this._instances.pointer
+  private _instances = new Atom<Record<SheetInstanceId, Sheet>>({})
+  readonly instancesP: Pointer<Record<SheetInstanceId, Sheet>> =
+    this._instances.pointer
 
-  private _objectTemplates = new Atom<{
-    [objectKey: string]: SheetObjectTemplate
-  }>({})
+  private _objectTemplates = new Atom<SheetTemplateObjectTemplateMap>({})
   readonly objectTemplatesP = this._objectTemplates.pointer
 
-  constructor(readonly project: Project, sheetId: string) {
+  constructor(readonly project: Project, sheetId: SheetId) {
     this.address = {...project.address, sheetId}
   }
 
-  getInstance(instanceId: string): Sheet {
+  getInstance(instanceId: SheetInstanceId): Sheet {
     let inst = this._instances.getState()[instanceId]
 
     if (!inst) {
@@ -36,15 +47,15 @@ export default class SheetTemplate {
   }
 
   getObjectTemplate(
-    key: string,
-    nativeObject: unknown,
-    config: SheetObjectConfig<$IntentionalAny>,
+    objectKey: ObjectAddressKey,
+    nativeObject: ObjectNativeObject,
+    config: SheetObjectPropTypeConfig,
   ): SheetObjectTemplate {
-    let template = this._objectTemplates.getState()[key]
+    let template = this._objectTemplates.getState()[objectKey]
 
     if (!template) {
-      template = new SheetObjectTemplate(this, key, nativeObject, config)
-      this._objectTemplates.setIn([key], template)
+      template = new SheetObjectTemplate(this, objectKey, nativeObject, config)
+      this._objectTemplates.setIn([objectKey], template)
     }
 
     return template

--- a/theatre/shared/src/testUtils.ts
+++ b/theatre/shared/src/testUtils.ts
@@ -8,6 +8,7 @@ import * as t from '@theatre/core/propTypes'
 import getStudio from '@theatre/studio/getStudio'
 import coreTicker from '@theatre/core/coreTicker'
 import globals from './globals'
+import type {SheetId} from './utils/ids'
 /* eslint-enable no-restricted-syntax */
 
 const defaultProps = {
@@ -32,7 +33,7 @@ export async function setupTestSheet(sheetState: SheetState_Historic) {
   const projectState: ProjectState_Historic = {
     definitionVersion: globals.currentProjectStateDefinitionVersion,
     sheetsById: {
-      Sheet: sheetState,
+      ['Sheet' as SheetId]: sheetState,
     },
     revisionHistory: [],
   }

--- a/theatre/shared/src/utils/Nominal.ts
+++ b/theatre/shared/src/utils/Nominal.ts
@@ -1,0 +1,37 @@
+/**
+ * Using a symbol, we can sort of add unique properties to arbitrary other types.
+ * So, we use this to our advantage to add a "marker" of information to strings using
+ * the {@link Nominal} type.
+ *
+ * Can be used with keys in pointers.
+ * This identifier shows in the expanded {@link Nominal} as `string & {[nominal]:"SequenceTrackId"}`,
+ * So, we're opting to keeping the identifier short.
+ */
+const nominal = Symbol()
+
+/**
+ * This creates an "opaque"/"nominal" type.
+ *
+ * Our primary use case is to be able to use with keys in pointers.
+ *
+ * Numbers cannot be added together if they are "nominal"
+ *
+ * See {@link nominal} for more details.
+ */
+export type Nominal<N extends string> = string & {[nominal]: N}
+
+declare global {
+  // Fix Object.entries and Object.keys definitions for Nominal strict records
+  interface ObjectConstructor {
+    /** Nominal: Extension to the Object prototype definition to properly manage {@link Nominal} keyed records */
+    keys<T extends Record<Nominal<string>, any>>(
+      obj: T,
+    ): any extends T ? never[] : Extract<keyof T, string>[]
+    /** Nominal: Extension to the Object prototype definition to properly manage {@link Nominal} keyed records */
+    entries<T extends Record<Nominal<string>, any>>(
+      obj: T,
+    ): any extends T
+      ? [never, never][]
+      : Array<{[P in keyof T]: [P, T[P]]}[Extract<keyof T, string>]>
+  }
+}

--- a/theatre/shared/src/utils/addresses.ts
+++ b/theatre/shared/src/utils/addresses.ts
@@ -3,12 +3,13 @@ import type {
   SerializableMap,
   SerializableValue,
 } from '@theatre/shared/utils/types'
+import type {ObjectAddressKey, ProjectId, SheetId, SheetInstanceId} from './ids'
 
 /**
  * Represents the address to a project
  */
 export interface ProjectAddress {
-  projectId: string
+  projectId: ProjectId
 }
 
 /**
@@ -22,8 +23,8 @@ export interface ProjectAddress {
  * ```
  */
 export interface SheetAddress extends ProjectAddress {
-  sheetId: string
-  sheetInstanceId: string
+  sheetId: SheetId
+  sheetInstanceId: SheetInstanceId
 }
 
 /**
@@ -36,7 +37,7 @@ export type WithoutSheetInstance<T extends SheetAddress> = Omit<
 >
 
 export type SheetInstanceOptional<T extends SheetAddress> =
-  WithoutSheetInstance<T> & {sheetInstanceId?: string | undefined}
+  WithoutSheetInstance<T> & {sheetInstanceId?: SheetInstanceId | undefined}
 
 /**
  * Represents the address to a Sheet's Object
@@ -51,7 +52,7 @@ export interface SheetObjectAddress extends SheetAddress {
    * obj.address.objectKey === 'foo'
    * ```
    */
-  objectKey: string
+  objectKey: ObjectAddressKey
 }
 
 export type PathToProp = Array<string | number>

--- a/theatre/shared/src/utils/ids.ts
+++ b/theatre/shared/src/utils/ids.ts
@@ -1,9 +1,10 @@
 import {nanoid as generateNonSecure} from 'nanoid/non-secure'
-import type {$IntentionalAny, Nominal} from './types'
+import type {Nominal} from './Nominal'
+import type {$IntentionalAny} from './types'
 
-export type KeyframeId = Nominal<string, 'KeyframeId'>
+export type KeyframeId = Nominal<'KeyframeId'>
 
-export function generateKeyframeId() {
+export function generateKeyframeId(): KeyframeId {
   return generateNonSecure(10) as KeyframeId
 }
 
@@ -11,10 +12,16 @@ export function asKeyframeId(s: string): KeyframeId {
   return s as $IntentionalAny
 }
 
-// @todo make nominal
-export type SequenceTrackId = string
+export type ProjectId = Nominal<'ProjectId'>
+export type SheetId = Nominal<'SheetId'>
+export type SheetInstanceId = Nominal<'SheetInstanceId'>
+export type PaneInstanceId = Nominal<'PaneInstanceId'>
+export type SequenceTrackId = Nominal<'SequenceTrackId'>
+export type ObjectAddressKey = Nominal<'ObjectAddressKey'>
+/** UI panels can contain a {@link PaneInstanceId} or something else. */
+export type UIPanelId = Nominal<'UIPanelId'>
 
-export function generateSequenceTrackId() {
+export function generateSequenceTrackId(): SequenceTrackId {
   return generateNonSecure(10) as $IntentionalAny as SequenceTrackId
 }
 

--- a/theatre/shared/src/utils/pointerDeep.ts
+++ b/theatre/shared/src/utils/pointerDeep.ts
@@ -2,11 +2,11 @@ import type {Pointer} from '@theatre/dataverse'
 import type {PathToProp} from './addresses'
 import type {$IntentionalAny} from './types'
 
-export default function pointerDeep(
-  base: Pointer<$IntentionalAny>,
+export default function pointerDeep<T>(
+  base: Pointer<T>,
   toAppend: PathToProp,
 ): Pointer<unknown> {
-  let p = base
+  let p = base as $IntentionalAny
   for (const k of toAppend) {
     p = p[k]
   }

--- a/theatre/shared/src/utils/types.ts
+++ b/theatre/shared/src/utils/types.ts
@@ -44,6 +44,13 @@ export type SerializablePrimitive =
   | boolean
   | {r: number; g: number; b: number; a: number}
 
+/**
+ * This type represents all values that can be safely serialized.
+ * Also, it's notable that this type is compatible for dataverse pointer traversal (everything
+ * is path accessible [e.g. `a.b.c`]).
+ *
+ * One example usage is for keyframe values or static overrides such as `Rgba`, `string`, `number`, and "compound values".
+ */
 export type SerializableValue<
   Primitives extends SerializablePrimitive = SerializablePrimitive,
 > = Primitives | SerializableMap
@@ -57,15 +64,13 @@ export type DeepPartialOfSerializableValue<T extends SerializableValue> =
       }
     : T
 
-export type StrictRecord<Key extends string, V> = {[K in Key]?: V}
-
 /**
- * This is supposed to create an "opaque" or "nominal" type, but since typescript
- * doesn't allow generic index signatures, we're leaving it be.
+ * This is equivalent to `Partial<Record<Key, V>>` being used to describe a sort of Map
+ * where the keys might not have values.
  *
- * TODO fix this once https://github.com/microsoft/TypeScript/pull/26797 lands (likely typescript 4.4)
+ * We do not use `Map`s, because they add comlpexity with converting to `JSON.stringify` + pointer types
  */
-export type Nominal<T, N extends string> = T
+export type StrictRecord<Key extends string, V> = {[K in Key]?: V}
 
 /**
  * TODO: We should deprecate this and just use `[start: number, end: number]`
@@ -81,4 +86,4 @@ export type $IntentionalAny = any
  * Represents the `x` or `y` value of getBoundingClientRect().
  * In other words, represents a distance from 0,0 in screen space.
  */
-export type PositionInScreenSpace = Nominal<number, 'ScreenSpaceDim'>
+export type PositionInScreenSpace = number

--- a/theatre/studio/src/Studio.ts
+++ b/theatre/studio/src/Studio.ts
@@ -20,6 +20,7 @@ import type * as _coreExports from '@theatre/core/coreExports'
 import type {OnDiskState} from '@theatre/core/projects/store/storeTypes'
 import type {Deferred} from '@theatre/shared/utils/defer'
 import {defer} from '@theatre/shared/utils/defer'
+import type {ProjectId} from '@theatre/shared/utils/ids'
 
 export type CoreExports = typeof _coreExports
 
@@ -27,10 +28,10 @@ export class Studio {
   readonly ui!: UI
   readonly publicApi: IStudio
   readonly address: {studioId: string}
-  readonly _projectsProxy: PointerProxy<Record<string, Project>> =
+  readonly _projectsProxy: PointerProxy<Record<ProjectId, Project>> =
     new PointerProxy(new Atom({}).pointer)
 
-  readonly projectsP: Pointer<Record<string, Project>> =
+  readonly projectsP: Pointer<Record<ProjectId, Project>> =
     this._projectsProxy.pointer
 
   private readonly _store = new StudioStore()
@@ -124,7 +125,7 @@ export class Studio {
     this._setProjectsP(coreBits.projectsP)
   }
 
-  private _setProjectsP(projectsP: Pointer<Record<string, Project>>) {
+  private _setProjectsP(projectsP: Pointer<Record<ProjectId, Project>>) {
     this._projectsProxy.setPointer(projectsP)
   }
 
@@ -218,6 +219,6 @@ export class Studio {
   }
 
   createContentOfSaveFile(projectId: string): OnDiskState {
-    return this._store.createContentOfSaveFile(projectId)
+    return this._store.createContentOfSaveFile(projectId as ProjectId)
   }
 }

--- a/theatre/studio/src/StudioStore/StudioStore.ts
+++ b/theatre/studio/src/StudioStore/StudioStore.ts
@@ -25,6 +25,7 @@ import type {OnDiskState} from '@theatre/core/projects/store/storeTypes'
 import {generateDiskStateRevision} from './generateDiskStateRevision'
 
 import createTransactionPrivateApi from './createTransactionPrivateApi'
+import type {ProjectId} from '@theatre/shared/utils/ids'
 
 export type Drafts = {
   historic: Draft<StudioHistoricState>
@@ -173,7 +174,7 @@ export default class StudioStore {
     this._reduxStore.dispatch(studioActions.historic.redo())
   }
 
-  createContentOfSaveFile(projectId: string): OnDiskState {
+  createContentOfSaveFile(projectId: ProjectId): OnDiskState {
     const projectState =
       this._reduxStore.getState().$persistent.historic.innerState.coreByProject[
         projectId

--- a/theatre/studio/src/TheatreStudio.ts
+++ b/theatre/studio/src/TheatreStudio.ts
@@ -16,6 +16,7 @@ import getStudio from './getStudio'
 import type React from 'react'
 import {debounce} from 'lodash-es'
 import type Sheet from '@theatre/core/sheets/Sheet'
+import type {PaneInstanceId, ProjectId} from '@theatre/shared/utils/ids'
 
 export interface ITransactionAPI {
   /**
@@ -116,7 +117,7 @@ export interface IExtension {
 
 export type PaneInstance<ClassName extends string> = {
   extensionId: string
-  instanceId: string
+  instanceId: PaneInstanceId
   definition: PaneClassDefinition
 }
 
@@ -471,10 +472,12 @@ export default class TheatreStudio implements IStudio {
   }
 
   destroyPane(paneId: string): void {
-    return getStudio().paneManager.destroyPane(paneId)
+    return getStudio().paneManager.destroyPane(paneId as PaneInstanceId)
   }
 
   createContentOfSaveFile(projectId: string): Record<string, unknown> {
-    return getStudio().createContentOfSaveFile(projectId) as $IntentionalAny
+    return getStudio().createContentOfSaveFile(
+      projectId as ProjectId,
+    ) as $IntentionalAny
   }
 }

--- a/theatre/studio/src/panels/BasePanel/BasePanel.tsx
+++ b/theatre/studio/src/panels/BasePanel/BasePanel.tsx
@@ -1,5 +1,6 @@
 import {val} from '@theatre/dataverse'
 import {usePrism} from '@theatre/react'
+import type {UIPanelId} from '@theatre/shared/utils/ids'
 import type {$IntentionalAny, VoidFn} from '@theatre/shared/utils/types'
 import getStudio from '@theatre/studio/getStudio'
 import type {PanelPosition} from '@theatre/studio/store/types'
@@ -8,7 +9,7 @@ import React, {useContext} from 'react'
 import useWindowSize from 'react-use/esm/useWindowSize'
 
 type PanelStuff = {
-  panelId: string
+  panelId: UIPanelId
   dims: {
     width: number
     height: number
@@ -64,7 +65,7 @@ const PanelContext = React.createContext<PanelStuff>(null as $IntentionalAny)
 export const usePanel = () => useContext(PanelContext)
 
 const BasePanel: React.FC<{
-  panelId: string
+  panelId: UIPanelId
   defaultPosition: PanelPosition
   minDims: {width: number; height: number}
 }> = ({panelId, children, defaultPosition, minDims}) => {

--- a/theatre/studio/src/panels/BasePanel/ExtensionPaneWrapper.tsx
+++ b/theatre/studio/src/panels/BasePanel/ExtensionPaneWrapper.tsx
@@ -11,6 +11,7 @@ import {ErrorBoundary} from 'react-error-boundary'
 import {IoClose} from 'react-icons/all'
 import getStudio from '@theatre/studio/getStudio'
 import {panelZIndexes} from '@theatre/studio/panels/BasePanel/common'
+import type {PaneInstanceId, UIPanelId} from '@theatre/shared/utils/ids'
 
 const defaultPosition: PanelPosition = {
   edges: {
@@ -28,7 +29,7 @@ const ExtensionPaneWrapper: React.FC<{
 }> = ({paneInstance}) => {
   return (
     <BasePanel
-      panelId={`pane-${paneInstance.instanceId}`}
+      panelId={`pane-${paneInstance.instanceId}` as UIPanelId}
       defaultPosition={defaultPosition}
       minDims={minDims}
     >
@@ -137,7 +138,9 @@ const Content: React.FC<{paneInstance: PaneInstance<$FixMe>}> = ({
 }) => {
   const Comp = paneInstance.definition.component
   const closePane = useCallback(() => {
-    getStudio().paneManager.destroyPane(paneInstance.instanceId)
+    getStudio().paneManager.destroyPane(
+      paneInstance.instanceId as PaneInstanceId,
+    )
   }, [paneInstance])
 
   return (

--- a/theatre/studio/src/panels/DetailPanel/ObjectDetails.tsx
+++ b/theatre/studio/src/panels/DetailPanel/ObjectDetails.tsx
@@ -1,6 +1,8 @@
 import React, {useMemo} from 'react'
 import DeterminePropEditor from './propEditors/DeterminePropEditor'
 import type SheetObject from '@theatre/core/sheetObjects/SheetObject'
+import type {Pointer} from '@theatre/dataverse'
+import type {$FixMe} from '@theatre/shared/utils/types'
 
 const ObjectDetails: React.FC<{
   objects: SheetObject[]
@@ -13,9 +15,9 @@ const ObjectDetails: React.FC<{
     <DeterminePropEditor
       key={key}
       obj={obj}
-      pointerToProp={obj.propsP}
+      pointerToProp={obj.propsP as Pointer<$FixMe>}
       propConfig={obj.template.config}
-      depth={1}
+      visualIndentation={1}
     />
   )
 }

--- a/theatre/studio/src/panels/DetailPanel/ProjectDetails/StateConflictRow.tsx
+++ b/theatre/studio/src/panels/DetailPanel/ProjectDetails/StateConflictRow.tsx
@@ -8,6 +8,7 @@ import useTooltip from '@theatre/studio/uiComponents/Popover/useTooltip'
 import BasicTooltip from '@theatre/studio/uiComponents/Popover/BasicTooltip'
 import type {$FixMe} from '@theatre/shared/utils/types'
 import DetailPanelButton from '@theatre/studio/uiComponents/DetailPanelButton'
+import type {ProjectId} from '@theatre/shared/utils/ids'
 
 const Container = styled.div`
   padding: 8px 10px;
@@ -37,7 +38,7 @@ const ChooseStateRow = styled.div`
   gap: 8px;
 `
 
-const StateConflictRow: React.FC<{projectId: string}> = ({projectId}) => {
+const StateConflictRow: React.FC<{projectId: ProjectId}> = ({projectId}) => {
   const loadingState = useVal(
     getStudio().atomP.ephemeral.coreByProject[projectId].loadingState,
   )
@@ -52,7 +53,7 @@ const StateConflictRow: React.FC<{projectId: string}> = ({projectId}) => {
 }
 
 const InConflict: React.FC<{
-  projectId: string
+  projectId: ProjectId
   loadingState: Extract<
     ProjectEphemeralState['loadingState'],
     {type: 'browserStateIsNotBasedOnDiskState'}

--- a/theatre/studio/src/panels/DetailPanel/propEditors/BooleanPropEditor.tsx
+++ b/theatre/studio/src/panels/DetailPanel/propEditors/BooleanPropEditor.tsx
@@ -1,20 +1,20 @@
 import type {PropTypeConfig_Boolean} from '@theatre/core/propTypes'
-import type SheetObject from '@theatre/core/sheetObjects/SheetObject'
 import React, {useCallback} from 'react'
 import {useEditingToolsForPrimitiveProp} from './utils/useEditingToolsForPrimitiveProp'
 import {SingleRowPropEditor} from './utils/SingleRowPropEditor'
 import styled from 'styled-components'
 import BasicCheckbox from '@theatre/studio/uiComponents/form/BasicCheckbox'
+import type {IPropEditorFC} from './utils/IPropEditorFC'
 
 const Input = styled(BasicCheckbox)`
   margin-left: 6px;
 `
 
-const BooleanPropEditor: React.FC<{
-  propConfig: PropTypeConfig_Boolean
-  pointerToProp: SheetObject['propsP']
-  obj: SheetObject
-}> = ({propConfig, pointerToProp, obj}) => {
+const BooleanPropEditor: IPropEditorFC<PropTypeConfig_Boolean> = ({
+  propConfig,
+  pointerToProp,
+  obj,
+}) => {
   const stuff = useEditingToolsForPrimitiveProp<boolean>(
     pointerToProp,
     obj,

--- a/theatre/studio/src/panels/DetailPanel/propEditors/CompoundPropEditor.tsx
+++ b/theatre/studio/src/panels/DetailPanel/propEditors/CompoundPropEditor.tsx
@@ -61,7 +61,7 @@ const SubProps = styled.div<{depth: number; lastSubIsComposite: boolean}>`
 
 const CompoundPropEditor: IPropEditorFC<
   PropTypeConfig_Compound<$IntentionalAny>
-> = ({pointerToProp, obj, propConfig, depth}) => {
+> = ({pointerToProp, obj, propConfig, visualIndentation: depth}) => {
   const propName = propConfig.label ?? last(getPointerParts(pointerToProp).path)
 
   const allSubs = Object.entries(propConfig.props)
@@ -154,7 +154,7 @@ const CompoundPropEditor: IPropEditorFC<
                 propConfig={subPropConfig}
                 pointerToProp={pointerToProp[subPropKey]}
                 obj={obj}
-                depth={depth + 1}
+                visualIndentation={depth + 1}
               />
             )
           },

--- a/theatre/studio/src/panels/DetailPanel/propEditors/CompoundPropEditor.tsx
+++ b/theatre/studio/src/panels/DetailPanel/propEditors/CompoundPropEditor.tsx
@@ -1,6 +1,5 @@
 import type {PropTypeConfig_Compound} from '@theatre/core/propTypes'
 import {isPropConfigComposite} from '@theatre/shared/propTypes/utils'
-import type SheetObject from '@theatre/core/sheetObjects/SheetObject'
 import type {$IntentionalAny} from '@theatre/shared/utils/types'
 import {getPointerParts} from '@theatre/dataverse'
 import last from 'lodash-es/last'
@@ -16,6 +15,7 @@ import {
 import DefaultOrStaticValueIndicator from './utils/DefaultValueIndicator'
 import {pointerEventsAutoInNormalMode} from '@theatre/studio/css'
 import useRefAndState from '@theatre/studio/utils/useRefAndState'
+import type {IPropEditorFC} from './utils/IPropEditorFC'
 
 const Container = styled.div`
   --step: 8px;
@@ -59,12 +59,9 @@ const SubProps = styled.div<{depth: number; lastSubIsComposite: boolean}>`
   /* padding: ${(props) => (props.lastSubIsComposite ? 0 : '4px')} 0; */
 `
 
-const CompoundPropEditor: React.FC<{
-  pointerToProp: SheetObject['propsP']
-  obj: SheetObject
-  propConfig: PropTypeConfig_Compound<$IntentionalAny>
-  depth: number
-}> = ({pointerToProp, obj, propConfig, depth}) => {
+const CompoundPropEditor: IPropEditorFC<
+  PropTypeConfig_Compound<$IntentionalAny>
+> = ({pointerToProp, obj, propConfig, depth}) => {
   const propName = propConfig.label ?? last(getPointerParts(pointerToProp).path)
 
   const allSubs = Object.entries(propConfig.props)

--- a/theatre/studio/src/panels/DetailPanel/propEditors/DeterminePropEditor.tsx
+++ b/theatre/studio/src/panels/DetailPanel/propEditors/DeterminePropEditor.tsx
@@ -9,15 +9,15 @@ import NumberPropEditor from './NumberPropEditor'
 import StringLiteralPropEditor from './StringLiteralPropEditor'
 import StringPropEditor from './StringPropEditor'
 import RgbaPropEditor from './RgbaPropEditor'
+import type {UnknownShorthandCompoundProps} from '@theatre/core/propTypes/internals'
 
 /**
  * Returns the PropTypeConfig by path. Assumes `path` is a valid prop path and that
  * it exists in obj.
  */
-export const getPropTypeByPointer = (
-  pointerToProp: SheetObject['propsP'],
-  obj: SheetObject,
-): PropTypeConfig => {
+export function getPropTypeByPointer<
+  Props extends UnknownShorthandCompoundProps,
+>(pointerToProp: SheetObject['propsP'], obj: SheetObject): PropTypeConfig {
   const rootConf = obj.template.config
 
   const p = getPointerParts(pointerToProp).path
@@ -67,7 +67,7 @@ type IPropEditorByPropType = {
     obj: SheetObject
     pointerToProp: Pointer<PropConfigByType<K>['valueType']>
     propConfig: PropConfigByType<K>
-    depth: number
+    visualIndentation: number
   }>
 }
 
@@ -81,12 +81,20 @@ const propEditorByPropType: IPropEditorByPropType = {
   rgba: RgbaPropEditor,
 }
 
-const DeterminePropEditor: React.FC<{
+export type IEditablePropertyProps<K extends PropTypeConfig['type']> = {
   obj: SheetObject
-  pointerToProp: SheetObject['propsP']
-  propConfig?: PropTypeConfig
-  depth: number
-}> = (p) => {
+  pointerToProp: Pointer<PropConfigByType<K>['valueType']>
+  propConfig: PropConfigByType<K>
+}
+
+type IDeterminePropEditorProps<K extends PropTypeConfig['type']> =
+  IEditablePropertyProps<K> & {
+    visualIndentation: number
+  }
+
+const DeterminePropEditor: React.FC<
+  IDeterminePropEditorProps<PropTypeConfig['type']>
+> = (p) => {
   const propConfig =
     p.propConfig ?? getPropTypeByPointer(p.pointerToProp, p.obj)
 
@@ -95,7 +103,7 @@ const DeterminePropEditor: React.FC<{
   return (
     <PropEditor
       obj={p.obj}
-      depth={p.depth}
+      visualIndentation={p.visualIndentation}
       // @ts-expect-error This is fine
       pointerToProp={p.pointerToProp}
       // @ts-expect-error This is fine

--- a/theatre/studio/src/panels/DetailPanel/propEditors/DeterminePropEditor.tsx
+++ b/theatre/studio/src/panels/DetailPanel/propEditors/DeterminePropEditor.tsx
@@ -1,6 +1,7 @@
 import type {PropTypeConfig} from '@theatre/core/propTypes'
 import type SheetObject from '@theatre/core/sheetObjects/SheetObject'
 import {getPointerParts} from '@theatre/dataverse'
+import type {Pointer} from '@theatre/dataverse'
 import React from 'react'
 import BooleanPropEditor from './BooleanPropEditor'
 import CompoundPropEditor from './CompoundPropEditor'
@@ -56,14 +57,21 @@ export const getPropTypeByPointer = (
   return conf
 }
 
-const propEditorByPropType: {
+type PropConfigByType<K extends PropTypeConfig['type']> = Extract<
+  PropTypeConfig,
+  {type: K}
+>
+
+type IPropEditorByPropType = {
   [K in PropTypeConfig['type']]: React.FC<{
     obj: SheetObject
-    pointerToProp: SheetObject['propsP']
-    propConfig: Extract<PropTypeConfig, {type: K}>
+    pointerToProp: Pointer<PropConfigByType<K>['valueType']>
+    propConfig: PropConfigByType<K>
     depth: number
   }>
-} = {
+}
+
+const propEditorByPropType: IPropEditorByPropType = {
   compound: CompoundPropEditor,
   number: NumberPropEditor,
   string: StringPropEditor,
@@ -88,6 +96,7 @@ const DeterminePropEditor: React.FC<{
     <PropEditor
       obj={p.obj}
       depth={p.depth}
+      // @ts-expect-error This is fine
       pointerToProp={p.pointerToProp}
       // @ts-expect-error This is fine
       propConfig={propConfig}

--- a/theatre/studio/src/panels/DetailPanel/propEditors/NumberPropEditor.tsx
+++ b/theatre/studio/src/panels/DetailPanel/propEditors/NumberPropEditor.tsx
@@ -1,15 +1,15 @@
 import type {PropTypeConfig_Number} from '@theatre/core/propTypes'
-import type SheetObject from '@theatre/core/sheetObjects/SheetObject'
 import BasicNumberInput from '@theatre/studio/uiComponents/form/BasicNumberInput'
 import React, {useCallback} from 'react'
 import {useEditingToolsForPrimitiveProp} from './utils/useEditingToolsForPrimitiveProp'
 import {SingleRowPropEditor} from './utils/SingleRowPropEditor'
+import type {IPropEditorFC} from './utils/IPropEditorFC'
 
-const NumberPropEditor: React.FC<{
-  propConfig: PropTypeConfig_Number
-  pointerToProp: SheetObject['propsP']
-  obj: SheetObject
-}> = ({propConfig, pointerToProp, obj}) => {
+const NumberPropEditor: IPropEditorFC<PropTypeConfig_Number> = ({
+  propConfig,
+  pointerToProp,
+  obj,
+}) => {
   const stuff = useEditingToolsForPrimitiveProp<number>(
     pointerToProp,
     obj,

--- a/theatre/studio/src/panels/DetailPanel/propEditors/RgbaPropEditor.tsx
+++ b/theatre/studio/src/panels/DetailPanel/propEditors/RgbaPropEditor.tsx
@@ -5,7 +5,6 @@ import {
   rgba2hex,
   parseRgbaFromHex,
 } from '@theatre/shared/utils/color'
-import type SheetObject from '@theatre/core/sheetObjects/SheetObject'
 import React, {useCallback, useRef} from 'react'
 import {useEditingToolsForPrimitiveProp} from './utils/useEditingToolsForPrimitiveProp'
 import {SingleRowPropEditor} from './utils/SingleRowPropEditor'
@@ -14,6 +13,7 @@ import styled from 'styled-components'
 import usePopover from '@theatre/studio/uiComponents/Popover/usePopover'
 import BasicStringInput from '@theatre/studio/uiComponents/form/BasicStringInput'
 import {popoverBackgroundColor} from '@theatre/studio/uiComponents/Popover/BasicPopover'
+import type {IPropEditorFC} from './utils/IPropEditorFC'
 
 const RowContainer = styled.div`
   display: flex;
@@ -60,18 +60,14 @@ const Popover = styled.div`
   box-shadow: none;
 `
 
-const RgbaPropEditor: React.FC<{
-  propConfig: PropTypeConfig_Rgba
-  pointerToProp: SheetObject['propsP']
-  obj: SheetObject
-}> = ({propConfig, pointerToProp, obj}) => {
+const RgbaPropEditor: IPropEditorFC<PropTypeConfig_Rgba> = ({
+  propConfig,
+  pointerToProp,
+  obj,
+}) => {
   const containerRef = useRef<HTMLDivElement>(null!)
 
-  const stuff = useEditingToolsForPrimitiveProp<Rgba>(
-    pointerToProp,
-    obj,
-    propConfig,
-  )
+  const stuff = useEditingToolsForPrimitiveProp(pointerToProp, obj, propConfig)
 
   const onChange = useCallback(
     (color: string) => {

--- a/theatre/studio/src/panels/DetailPanel/propEditors/StringLiteralPropEditor.tsx
+++ b/theatre/studio/src/panels/DetailPanel/propEditors/StringLiteralPropEditor.tsx
@@ -1,17 +1,15 @@
 import type {PropTypeConfig_StringLiteral} from '@theatre/core/propTypes'
-import type SheetObject from '@theatre/core/sheetObjects/SheetObject'
 import React, {useCallback} from 'react'
 import {useEditingToolsForPrimitiveProp} from './utils/useEditingToolsForPrimitiveProp'
 import type {$IntentionalAny} from '@theatre/shared/utils/types'
 import BasicSwitch from '@theatre/studio/uiComponents/form/BasicSwitch'
 import BasicSelect from '@theatre/studio/uiComponents/form/BasicSelect'
 import {SingleRowPropEditor} from './utils/SingleRowPropEditor'
+import type {IPropEditorFC} from './utils/IPropEditorFC'
 
-const StringLiteralPropEditor: React.FC<{
-  propConfig: PropTypeConfig_StringLiteral<$IntentionalAny>
-  pointerToProp: SheetObject['propsP']
-  obj: SheetObject
-}> = ({propConfig, pointerToProp, obj}) => {
+const StringLiteralPropEditor: IPropEditorFC<
+  PropTypeConfig_StringLiteral<$IntentionalAny>
+> = ({propConfig, pointerToProp, obj}) => {
   const stuff = useEditingToolsForPrimitiveProp<string>(
     pointerToProp,
     obj,

--- a/theatre/studio/src/panels/DetailPanel/propEditors/StringPropEditor.tsx
+++ b/theatre/studio/src/panels/DetailPanel/propEditors/StringPropEditor.tsx
@@ -1,15 +1,15 @@
-import type {PropTypeConfig_String} from '@theatre/core/propTypes'
-import type SheetObject from '@theatre/core/sheetObjects/SheetObject'
 import React from 'react'
+import type {PropTypeConfig_String} from '@theatre/core/propTypes'
 import {useEditingToolsForPrimitiveProp} from './utils/useEditingToolsForPrimitiveProp'
 import {SingleRowPropEditor} from './utils/SingleRowPropEditor'
 import BasicStringInput from '@theatre/studio/uiComponents/form/BasicStringInput'
+import type {IPropEditorFC} from './utils/IPropEditorFC'
 
-const StringPropEditor: React.FC<{
-  propConfig: PropTypeConfig_String
-  pointerToProp: SheetObject['propsP']
-  obj: SheetObject
-}> = ({propConfig, pointerToProp, obj}) => {
+const StringPropEditor: IPropEditorFC<PropTypeConfig_String> = ({
+  propConfig,
+  pointerToProp,
+  obj,
+}) => {
   const stuff = useEditingToolsForPrimitiveProp<string>(
     pointerToProp,
     obj,

--- a/theatre/studio/src/panels/DetailPanel/propEditors/utils/IPropEditorFC.ts
+++ b/theatre/studio/src/panels/DetailPanel/propEditors/utils/IPropEditorFC.ts
@@ -1,0 +1,12 @@
+import type {IBasePropType} from '@theatre/core/propTypes'
+import type SheetObject from '@theatre/core/sheetObjects/SheetObject'
+import type {Pointer} from '@theatre/dataverse'
+
+/** Helper for defining consistent prop editor components */
+export type IPropEditorFC<TPropTypeConfig extends IBasePropType<string, any>> =
+  React.FC<{
+    propConfig: TPropTypeConfig
+    pointerToProp: Pointer<TPropTypeConfig['valueType']>
+    obj: SheetObject
+    depth: number
+  }>

--- a/theatre/studio/src/panels/DetailPanel/propEditors/utils/IPropEditorFC.ts
+++ b/theatre/studio/src/panels/DetailPanel/propEditors/utils/IPropEditorFC.ts
@@ -8,5 +8,5 @@ export type IPropEditorFC<TPropTypeConfig extends IBasePropType<string, any>> =
     propConfig: TPropTypeConfig
     pointerToProp: Pointer<TPropTypeConfig['valueType']>
     obj: SheetObject
-    depth: number
+    visualIndentation: number
   }>

--- a/theatre/studio/src/panels/DetailPanel/propEditors/utils/SingleRowPropEditor.tsx
+++ b/theatre/studio/src/panels/DetailPanel/propEditors/utils/SingleRowPropEditor.tsx
@@ -1,6 +1,6 @@
 import type * as propTypes from '@theatre/core/propTypes'
-import type SheetObject from '@theatre/core/sheetObjects/SheetObject'
 import {getPointerParts} from '@theatre/dataverse'
+import type {Pointer} from '@theatre/dataverse'
 import useContextMenu from '@theatre/studio/uiComponents/simpleContextMenu/useContextMenu'
 import useRefAndState from '@theatre/studio/utils/useRefAndState'
 import {last} from 'lodash-es'
@@ -108,11 +108,21 @@ const InputContainer = styled.div`
   flex-grow: 0;
 `
 
-export const SingleRowPropEditor: React.FC<{
+type ISingleRowPropEditorProps<T> = {
   propConfig: propTypes.PropTypeConfig
-  pointerToProp: SheetObject['propsP']
+  pointerToProp: Pointer<T>
   stuff: ReturnType<typeof useEditingToolsForPrimitiveProp>
-}> = ({propConfig, pointerToProp, stuff, children}) => {
+}
+
+export function SingleRowPropEditor<T>({
+  propConfig,
+  pointerToProp,
+  stuff,
+  children,
+}: React.PropsWithChildren<ISingleRowPropEditorProps<T>>): React.ReactElement<
+  any,
+  any
+> | null {
   const label = propConfig.label ?? last(getPointerParts(pointerToProp).path)
 
   const [propNameContainerRef, propNameContainer] =

--- a/theatre/studio/src/panels/DetailPanel/propEditors/utils/SingleRowPropEditor.tsx
+++ b/theatre/studio/src/panels/DetailPanel/propEditors/utils/SingleRowPropEditor.tsx
@@ -119,7 +119,7 @@ export const SingleRowPropEditor: React.FC<{
     useRefAndState<HTMLDivElement | null>(null)
 
   const [contextMenu] = useContextMenu(propNameContainer, {
-    items: stuff.contextMenuItems,
+    menuItems: stuff.contextMenuItems,
   })
 
   const color = shadeToColor[stuff.shade]

--- a/theatre/studio/src/panels/DetailPanel/propEditors/utils/useEditingToolsForPrimitiveProp.tsx
+++ b/theatre/studio/src/panels/DetailPanel/propEditors/utils/useEditingToolsForPrimitiveProp.tsx
@@ -5,7 +5,7 @@ import type Scrub from '@theatre/studio/Scrub'
 import type {IContextMenuItem} from '@theatre/studio/uiComponents/simpleContextMenu/useContextMenu'
 import getDeep from '@theatre/shared/utils/getDeep'
 import {usePrism} from '@theatre/react'
-import type {$FixMe, SerializablePrimitive} from '@theatre/shared/utils/types'
+import type {SerializablePrimitive} from '@theatre/shared/utils/types'
 import {getPointerParts, prism, val} from '@theatre/dataverse'
 import type {Pointer} from '@theatre/dataverse'
 import get from 'lodash-es/get'
@@ -15,6 +15,7 @@ import DefaultOrStaticValueIndicator from './DefaultValueIndicator'
 import NextPrevKeyframeCursors from './NextPrevKeyframeCursors'
 import type {PropTypeConfig} from '@theatre/core/propTypes'
 import {isPropConfSequencable} from '@theatre/shared/propTypes/utils'
+import type {SequenceTrackId} from '@theatre/shared/utils/ids'
 
 interface CommonStuff<T> {
   value: T
@@ -147,7 +148,7 @@ export function useEditingToolsForPrimitiveProp<
           },
         })
 
-        const sequenceTrcackId = possibleSequenceTrackId as $FixMe as string
+        const sequenceTrackId = possibleSequenceTrackId as SequenceTrackId
         const nearbyKeyframes = prism.sub(
           'lcr',
           (): NearbyKeyframes => {
@@ -155,7 +156,7 @@ export function useEditingToolsForPrimitiveProp<
               obj.template.project.pointers.historic.sheetsById[
                 obj.address.sheetId
               ].sequence.tracksByObject[obj.address.objectKey].trackData[
-                sequenceTrcackId
+                sequenceTrackId
               ],
             )
             if (!track || track.keyframes.length === 0) return {}
@@ -186,7 +187,7 @@ export function useEditingToolsForPrimitiveProp<
               }
             }
           },
-          [sequenceTrcackId],
+          [sequenceTrackId],
         )
 
         let shade: Shade

--- a/theatre/studio/src/panels/DetailPanel/propEditors/utils/useEditingToolsForPrimitiveProp.tsx
+++ b/theatre/studio/src/panels/DetailPanel/propEditors/utils/useEditingToolsForPrimitiveProp.tsx
@@ -7,6 +7,7 @@ import getDeep from '@theatre/shared/utils/getDeep'
 import {usePrism} from '@theatre/react'
 import type {$FixMe, SerializablePrimitive} from '@theatre/shared/utils/types'
 import {getPointerParts, prism, val} from '@theatre/dataverse'
+import type {Pointer} from '@theatre/dataverse'
 import get from 'lodash-es/get'
 import last from 'lodash-es/last'
 import React from 'react'
@@ -47,7 +48,7 @@ type Stuff<T> = Default<T> | Static<T> | Sequenced<T>
 export function useEditingToolsForPrimitiveProp<
   T extends SerializablePrimitive,
 >(
-  pointerToProp: SheetObject['propsP'],
+  pointerToProp: Pointer<T>,
   obj: SheetObject,
   propConfig: PropTypeConfig,
 ): Stuff<T> {

--- a/theatre/studio/src/panels/OutlinePanel/ObjectsList/ObjectsList.tsx
+++ b/theatre/studio/src/panels/OutlinePanel/ObjectsList/ObjectsList.tsx
@@ -26,7 +26,7 @@ const ObjectsList: React.FC<{
               <ObjectItem
                 depth={depth}
                 key={'objectPath(' + objectPath + ')'}
-                sheetObject={object}
+                sheetObject={object!}
               />
             )
           })}

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/BasicKeyframedTrack.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/BasicKeyframedTrack.tsx
@@ -44,7 +44,10 @@ const BasicKeyframedTrack: React.FC<BasicKeyframedTracksProps> = React.memo(
           selection: val(selectionAtom.pointer.current),
         }
       } else {
-        return {selectedKeyframeIds: {}, selection: undefined}
+        return {
+          selectedKeyframeIds: {},
+          selection: undefined,
+        }
       }
     }, [layoutP, leaf.trackId])
 

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/BasicKeyframedTrack.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/BasicKeyframedTrack.tsx
@@ -8,6 +8,7 @@ import {val} from '@theatre/dataverse'
 import React from 'react'
 import styled from 'styled-components'
 import KeyframeEditor from './KeyframeEditor/KeyframeEditor'
+import type {IContextMenuItem} from '@theatre/studio/uiComponents/simpleContextMenu/useContextMenu'
 import useContextMenu from '@theatre/studio/uiComponents/simpleContextMenu/useContextMenu'
 import useRefAndState from '@theatre/studio/utils/useRefAndState'
 import getStudio from '@theatre/studio/getStudio'
@@ -85,7 +86,7 @@ function useBasicKeyframedTrackContextMenu(
   props: BasicKeyframedTracksProps,
 ) {
   return useContextMenu(node, {
-    items: () => {
+    menuItems: () => {
       const selectionKeyframes =
         val(getStudio()!.atomP.ahistoric.clipboard.keyframes) || []
 
@@ -101,7 +102,7 @@ function useBasicKeyframedTrackContextMenu(
 function pasteKeyframesContextMenuItem(
   props: BasicKeyframedTracksProps,
   keyframes: Keyframe[],
-) {
+): IContextMenuItem {
   return {
     label: 'Paste Keyframes',
     callback: () => {

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/KeyframeEditor/Connector.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/KeyframeEditor/Connector.tsx
@@ -12,7 +12,7 @@ import type {
   SequenceEditorPanelLayout,
   DopeSheetSelection,
 } from '@theatre/studio/panels/SequenceEditorPanel/layout/layout'
-import {DOT_SIZE_PX} from './Dot'
+import {DOT_SIZE_PX} from './KeyframeDot'
 import type KeyframeEditor from './KeyframeEditor'
 import type Sequence from '@theatre/core/sequences/Sequence'
 import usePopover from '@theatre/studio/uiComponents/Popover/usePopover'
@@ -250,7 +250,7 @@ function useConnectorContextMenu(
 ) {
   const maybeKeyframeIds = selectedKeyframeIdsIfInSingleTrack(props.selection)
   return useContextMenu(node, {
-    items: () => {
+    menuItems: () => {
       return [
         {
           label: maybeKeyframeIds ? 'Copy Selection' : 'Copy both Keyframes',

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/KeyframeEditor/KeyframeDot.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/KeyframeEditor/KeyframeDot.tsx
@@ -92,7 +92,7 @@ const HitZone = styled.div`
 type IKeyframeDotProps = IKeyframeEditorProps
 
 /** The ◆ you can grab onto in "keyframe editor" (aka "dope sheet" in other programs) */
-const KeyframeDot: React.FC<IKeyframeDotProps> = (props) => {
+const KeyframeDot: React.VFC<IKeyframeDotProps> = (props) => {
   const [ref, node] = useRefAndState<HTMLDivElement | null>(null)
 
   const [isDragging] = useDragKeyframe(node, props)

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/KeyframeEditor/KeyframeEditor.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/KeyframeEditor/KeyframeEditor.tsx
@@ -12,7 +12,7 @@ import {val} from '@theatre/dataverse'
 import React from 'react'
 import styled from 'styled-components'
 import Connector from './Connector'
-import Dot from './Dot'
+import KeyframeDot from './KeyframeDot'
 
 const Container = styled.div`
   position: absolute;
@@ -20,14 +20,16 @@ const Container = styled.div`
 
 const noConnector = <></>
 
-const KeyframeEditor: React.FC<{
+export type IKeyframeEditorProps = {
   index: number
   keyframe: Keyframe
   trackData: TrackData
   layoutP: Pointer<SequenceEditorPanelLayout>
   leaf: SequenceEditorTree_PrimitiveProp
   selection: undefined | DopeSheetSelection
-}> = (props) => {
+}
+
+const KeyframeEditor: React.FC<IKeyframeEditorProps> = (props) => {
   const {index, trackData} = props
   const cur = trackData.keyframes[index]
   const next = trackData.keyframes[index + 1]
@@ -45,7 +47,7 @@ const KeyframeEditor: React.FC<{
         }px))`,
       }}
     >
-      <Dot {...props} />
+      <KeyframeDot {...props} />
       {connected ? <Connector {...props} /> : noConnector}
     </Container>
   )

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/DopeSheetSelectionView.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/DopeSheetSelectionView.tsx
@@ -79,8 +79,8 @@ function useCaptureSelection(
 
           val(layoutP.selectionAtom).setState({current: undefined})
         },
-        onDrag(dx, dy, event) {
-          const state = ref.current!
+        onDrag(_dx, _dy, event) {
+          // const state = ref.current!
           const rect = containerNode!.getBoundingClientRect()
 
           const posInScaledSpace = event.clientX - rect.left
@@ -97,24 +97,12 @@ function useCaptureSelection(
           const selection = utils.boundsToSelection(layoutP, ref.current)
           val(layoutP.selectionAtom).setState({current: selection})
         },
-        onDragEnd(dragHappened) {
+        onDragEnd(_dragHappened) {
           ref.current = null
         },
       }
     }, [layoutP, containerNode, ref]),
   )
-
-  // useEffect(() => {
-  //   if (!containerNode) return
-  //   const onClick = () => {
-
-  //   }
-  //   containerNode.addEventListener('click', onClick)
-
-  //   return () => {
-  //     containerNode.removeEventListener('click', onClick)
-  //   }
-  // }, [containerNode])
 
   return state
 }
@@ -131,16 +119,11 @@ namespace utils {
     primitiveProp(layoutP, leaf, bounds, selection) {
       const {sheetObject, trackId} = leaf
       const trackData = val(
-        getStudio()!.atomP.historic.coreByProject[sheetObject.address.projectId]
+        getStudio().atomP.historic.coreByProject[sheetObject.address.projectId]
           .sheetsById[sheetObject.address.sheetId].sequence.tracksByObject[
           sheetObject.address.objectKey
         ].trackData[trackId],
       )!
-      const toCollect = trackData!.keyframes.filter(
-        (kf) =>
-          kf.position >= bounds.positions[0] &&
-          kf.position <= bounds.positions[1],
-      )
 
       for (const kf of trackData.keyframes) {
         if (kf.position <= bounds.positions[0]) continue

--- a/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/BasicKeyframedTrack/BasicKeyframedTrack.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/BasicKeyframedTrack/BasicKeyframedTrack.tsx
@@ -25,7 +25,7 @@ export type ExtremumSpace = {
   lock(): VoidFn
 }
 
-const BasicKeyframedTrack: React.FC<{
+const BasicKeyframedTrack: React.VFC<{
   layoutP: Pointer<SequenceEditorPanelLayout>
   sheetObject: SheetObject
   pathToProp: PathToProp
@@ -102,7 +102,7 @@ const BasicKeyframedTrack: React.FC<{
         sheetObject={sheetObject}
         trackId={trackId}
         isScalar={propConfig.type === 'number'}
-        key={'keyframe-' + kf.id}
+        key={kf.id}
         extremumSpace={cachedExtremumSpace.current}
         color={color}
       />

--- a/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/BasicKeyframedTrack/KeyframeEditor/Curve.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/BasicKeyframedTrack/KeyframeEditor/Curve.tsx
@@ -15,7 +15,7 @@ const SVGPath = styled.path`
 
 type IProps = Parameters<typeof KeyframeEditor>[0]
 
-const Curve: React.FC<IProps> = (props) => {
+const Curve: React.VFC<IProps> = (props) => {
   const {index, trackData} = props
   const cur = trackData.keyframes[index]
   const next = trackData.keyframes[index + 1]

--- a/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/BasicKeyframedTrack/KeyframeEditor/Curve.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/BasicKeyframedTrack/KeyframeEditor/Curve.tsx
@@ -109,7 +109,7 @@ function useConnectorContextMenu(node: SVGElement | null, props: IProps) {
   const next = trackData.keyframes[index + 1]
 
   return useContextMenu(node, {
-    items: () => {
+    menuItems: () => {
       return [
         {
           label: 'Delete',

--- a/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/BasicKeyframedTrack/KeyframeEditor/CurveHandle.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/BasicKeyframedTrack/KeyframeEditor/CurveHandle.tsx
@@ -49,7 +49,7 @@ type Which = 'left' | 'right'
 
 type IProps = Parameters<typeof KeyframeEditor>[0] & {which: Which}
 
-const CurveHandle: React.FC<IProps> = (props) => {
+const CurveHandle: React.VFC<IProps> = (props) => {
   const [ref, node] = useRefAndState<SVGCircleElement | null>(null)
 
   const {index, trackData} = props

--- a/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/BasicKeyframedTrack/KeyframeEditor/CurveHandle.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/BasicKeyframedTrack/KeyframeEditor/CurveHandle.tsx
@@ -243,7 +243,7 @@ function useOurDrags(node: SVGCircleElement | null, props: IProps): void {
 
 function useOurContextMenu(node: SVGCircleElement | null, props: IProps) {
   return useContextMenu(node, {
-    items: () => {
+    menuItems: () => {
       return [
         {
           label: 'Delete',

--- a/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/BasicKeyframedTrack/KeyframeEditor/GraphEditorDotNonScalar.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/BasicKeyframedTrack/KeyframeEditor/GraphEditorDotNonScalar.tsx
@@ -55,7 +55,7 @@ const HitZone = styled.circle`
 
 type IProps = Parameters<typeof KeyframeEditor>[0] & {which: 'left' | 'right'}
 
-const GraphEditorDotNonScalar: React.FC<IProps> = (props) => {
+const GraphEditorDotNonScalar: React.VFC<IProps> = (props) => {
   const [ref, node] = useRefAndState<SVGCircleElement | null>(null)
 
   const {index, trackData} = props

--- a/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/BasicKeyframedTrack/KeyframeEditor/GraphEditorDotNonScalar.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/BasicKeyframedTrack/KeyframeEditor/GraphEditorDotNonScalar.tsx
@@ -181,7 +181,7 @@ function useDragKeyframe(
 
 function useKeyframeContextMenu(node: SVGCircleElement | null, props: IProps) {
   return useContextMenu(node, {
-    items: () => {
+    menuItems: () => {
       return [
         {
           label: 'Delete',

--- a/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/BasicKeyframedTrack/KeyframeEditor/GraphEditorDotScalar.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/BasicKeyframedTrack/KeyframeEditor/GraphEditorDotScalar.tsx
@@ -55,7 +55,7 @@ const HitZone = styled.circle`
 
 type IProps = Parameters<typeof KeyframeEditor>[0]
 
-const GraphEditorDotScalar: React.FC<IProps> = (props) => {
+const GraphEditorDotScalar: React.VFC<IProps> = (props) => {
   const [ref, node] = useRefAndState<SVGCircleElement | null>(null)
 
   const {index, trackData} = props

--- a/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/BasicKeyframedTrack/KeyframeEditor/GraphEditorDotScalar.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/BasicKeyframedTrack/KeyframeEditor/GraphEditorDotScalar.tsx
@@ -235,7 +235,7 @@ function useDragKeyframe(
 
 function useKeyframeContextMenu(node: SVGCircleElement | null, props: IProps) {
   return useContextMenu(node, {
-    items: () => {
+    menuItems: () => {
       return [
         {
           label: 'Delete',

--- a/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/BasicKeyframedTrack/KeyframeEditor/GraphEditorNonScalarDash.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/BasicKeyframedTrack/KeyframeEditor/GraphEditorNonScalarDash.tsx
@@ -17,7 +17,7 @@ const SVGPath = styled.path`
 
 type IProps = Parameters<typeof KeyframeEditor>[0]
 
-const GraphEditorNonScalarDash: React.FC<IProps> = (props) => {
+const GraphEditorNonScalarDash: React.VFC<IProps> = (props) => {
   const {index, trackData} = props
 
   const pathD = `M 0 0 L 1 1`

--- a/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/BasicKeyframedTrack/KeyframeEditor/KeyframeEditor.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/BasicKeyframedTrack/KeyframeEditor/KeyframeEditor.tsx
@@ -23,7 +23,7 @@ const Container = styled.g`
 
 const noConnector = <></>
 
-const KeyframeEditor: React.FC<{
+type IKeyframeEditorProps = {
   index: number
   keyframe: Keyframe
   trackData: TrackData
@@ -34,7 +34,9 @@ const KeyframeEditor: React.FC<{
   isScalar: boolean
   color: keyof typeof graphEditorColors
   propConfig: PropTypeConfig_AllSimples
-}> = (props) => {
+}
+
+const KeyframeEditor: React.VFC<IKeyframeEditorProps> = (props) => {
   const {index, trackData, isScalar} = props
   const cur = trackData.keyframes[index]
   const next = trackData.keyframes[index + 1]

--- a/theatre/studio/src/panels/SequenceEditorPanel/RightOverlay/FocusRangeZone/FocusRangeStrip.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/RightOverlay/FocusRangeZone/FocusRangeStrip.tsx
@@ -132,9 +132,8 @@ const FocusRangeStrip: React.FC<{
   )
 
   const [contextMenu] = useContextMenu(rangeStripNode, {
-    items: () => {
+    menuItems: () => {
       const sheet = val(layoutP.sheet)
-
       const existingRange = existingRangeD.getValue()
       return [
         {

--- a/theatre/studio/src/panels/SequenceEditorPanel/RightOverlay/HorizontalScrollbar.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/RightOverlay/HorizontalScrollbar.tsx
@@ -21,8 +21,8 @@ const Container = styled.div`
   width: 100%;
   left: 12px;
   /* bottom: 8px; */
-  ${pointerEventsAutoInNormalMode};
   z-index: ${() => zIndexes.horizontalScrollbar};
+  ${pointerEventsAutoInNormalMode}
 `
 
 const TimeThread = styled.div`

--- a/theatre/studio/src/panels/SequenceEditorPanel/SequenceEditorPanel.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/SequenceEditorPanel.tsx
@@ -27,6 +27,7 @@ import {
   TitleBar_Piece,
   TitleBar_Punctuation,
 } from '@theatre/studio/panels/BasePanel/common'
+import type {UIPanelId} from '@theatre/shared/utils/ids'
 
 const Container = styled(PanelWrapper)`
   z-index: ${panelZIndexes.sequenceEditorPanel};
@@ -58,7 +59,7 @@ export const zIndexes = (() => {
   // sort the z-indexes
   let i = -1
   for (const key of Object.keys(s)) {
-    s[key as unknown as keyof typeof s] = i
+    s[key] = i
     i++
   }
 
@@ -83,10 +84,10 @@ const defaultPosition: PanelPosition = {
 
 const minDims = {width: 800, height: 200}
 
-const SequenceEditorPanel: React.FC<{}> = (props) => {
+const SequenceEditorPanel: React.VFC<{}> = (props) => {
   return (
     <BasePanel
-      panelId="sequenceEditor"
+      panelId={'sequenceEditor' as UIPanelId}
       defaultPosition={defaultPosition}
       minDims={minDims}
     >
@@ -95,7 +96,7 @@ const SequenceEditorPanel: React.FC<{}> = (props) => {
   )
 }
 
-const Content: React.FC<{}> = () => {
+const Content: React.VFC<{}> = () => {
   const {dims} = usePanel()
 
   return usePrism(() => {

--- a/theatre/studio/src/panels/SequenceEditorPanel/layout/layout.ts
+++ b/theatre/studio/src/panels/SequenceEditorPanel/layout/layout.ts
@@ -14,6 +14,11 @@ import {Atom, prism, val} from '@theatre/dataverse'
 import type {SequenceEditorTree} from './tree'
 import {calculateSequenceEditorTree} from './tree'
 import {clamp} from 'lodash-es'
+import type {
+  KeyframeId,
+  ObjectAddressKey,
+  SequenceTrackId,
+} from '@theatre/shared/utils/ids'
 
 // A Side is either the left side of the panel or the right side
 type DimsOfPanelPart = {
@@ -41,20 +46,20 @@ export type PanelDims = {
 export type DopeSheetSelection = {
   type: 'DopeSheetSelection'
   byObjectKey: StrictRecord<
-    string,
+    ObjectAddressKey,
     {
       byTrackId: StrictRecord<
-        string,
+        SequenceTrackId,
         {
-          byKeyframeId: StrictRecord<string, true>
+          byKeyframeId: StrictRecord<KeyframeId, true>
         }
       >
     }
   >
   getDragHandlers(
     origin: PropAddress & {
-      trackId: string
-      keyframeId: string
+      trackId: SequenceTrackId
+      keyframeId: KeyframeId
       positionAtStartOfDrag: number
       domNode: Element
     },
@@ -156,8 +161,8 @@ export type SequenceEditorPanelLayout = {
   selectionAtom: Atom<{current?: DopeSheetSelection}>
 }
 
-// type UnitSpaceProression = Nominal<number, 'unitSpaceProgression'>
-// type ClippedSpaceProgression = Nominal<number, 'ClippedSpaceProgression'>
+// type UnitSpaceProression = number
+// type ClippedSpaceProgression = number
 
 /**
  * This means the left side of the panel is 20% of its width, and the

--- a/theatre/studio/src/panels/SequenceEditorPanel/layout/tree.ts
+++ b/theatre/studio/src/panels/SequenceEditorPanel/layout/tree.ts
@@ -87,8 +87,10 @@ export const calculateSequenceEditorTree = (
   topSoFar += tree.nodeHeight
   nSoFar += 1
 
-  for (const [_, sheetObject] of Object.entries(val(sheet.objectsP))) {
-    addObject(sheetObject, tree.children, tree.depth + 1)
+  for (const sheetObject of Object.values(val(sheet.objectsP))) {
+    if (sheetObject) {
+      addObject(sheetObject, tree.children, tree.depth + 1)
+    }
   }
   tree.heightIncludingChildren = topSoFar - tree.top
 

--- a/theatre/studio/src/selectors.ts
+++ b/theatre/studio/src/selectors.ts
@@ -3,7 +3,9 @@ import type Sequence from '@theatre/core/sequences/Sequence'
 import type SheetObject from '@theatre/core/sheetObjects/SheetObject'
 import type Sheet from '@theatre/core/sheets/Sheet'
 import {val} from '@theatre/dataverse'
+import type {$IntentionalAny} from '@theatre/dataverse/src/types'
 import {isSheet, isSheetObject} from '@theatre/shared/instanceTypes'
+import type {SheetId} from '@theatre/shared/utils/ids'
 import {uniq} from 'lodash-es'
 import getStudio from './getStudio'
 import type {OutlineSelectable, OutlineSelection} from './store/types'
@@ -46,7 +48,7 @@ export const getSelectedInstanceOfSheetId = (
     ]
 
   const instanceId = val(
-    projectStateP.stateBySheetId[selectedSheetId].selectedInstanceId,
+    projectStateP.stateBySheetId[selectedSheetId as SheetId].selectedInstanceId,
   )
 
   const template = val(project.sheetTemplatesP[selectedSheetId])
@@ -59,8 +61,12 @@ export const getSelectedInstanceOfSheetId = (
     // @todo #perf this will update every time an instance is added/removed.
     const allInstances = val(template.instancesP)
 
-    return allInstances[Object.keys(allInstances)[0]]
+    return allInstances[keys(allInstances)[0]]
   }
+}
+
+function keys<T extends object>(obj: T): Exclude<keyof T, symbol | number>[] {
+  return Object.keys(obj) as $IntentionalAny
 }
 
 /**

--- a/theatre/studio/src/store/stateEditors.ts
+++ b/theatre/studio/src/store/stateEditors.ts
@@ -1,4 +1,5 @@
 import type {
+  HistoricPositionalSequence,
   Keyframe,
   SheetState_Historic,
 } from '@theatre/core/projects/store/types/SheetState_Historic'
@@ -11,7 +12,11 @@ import type {
   WithoutSheetInstance,
 } from '@theatre/shared/utils/addresses'
 import {encodePathToProp} from '@theatre/shared/utils/addresses'
-import type {KeyframeId} from '@theatre/shared/utils/ids'
+import type {
+  KeyframeId,
+  SequenceTrackId,
+  UIPanelId,
+} from '@theatre/shared/utils/ids'
 import {
   generateKeyframeId,
   generateSequenceTrackId,
@@ -72,7 +77,7 @@ namespace stateEditors {
     export namespace historic {
       export namespace panelPositions {
         export function setPanelPosition(p: {
-          panelId: string
+          panelId: UIPanelId
           position: PanelPosition
         }) {
           const h = drafts().historic
@@ -429,7 +434,9 @@ namespace stateEditors {
         }
 
         export namespace sequence {
-          export function _ensure(p: WithoutSheetInstance<SheetAddress>) {
+          export function _ensure(
+            p: WithoutSheetInstance<SheetAddress>,
+          ): HistoricPositionalSequence {
             const s = stateEditors.coreByProject.historic.sheetsById._ensure(p)
             s.sequence ??= {
               subUnitsPerUnit: 30,
@@ -529,7 +536,9 @@ namespace stateEditors {
           }
 
           function _getTrack(
-            p: WithoutSheetInstance<SheetObjectAddress> & {trackId: string},
+            p: WithoutSheetInstance<SheetObjectAddress> & {
+              trackId: SequenceTrackId
+            },
           ) {
             return _ensureTracksOfObject(p).trackData[p.trackId]
           }
@@ -540,7 +549,7 @@ namespace stateEditors {
            */
           export function setKeyframeAtPosition<T>(
             p: WithoutSheetInstance<SheetObjectAddress> & {
-              trackId: string
+              trackId: SequenceTrackId
               position: number
               handles?: [number, number, number, number]
               value: T
@@ -585,7 +594,7 @@ namespace stateEditors {
 
           export function unsetKeyframeAtPosition(
             p: WithoutSheetInstance<SheetObjectAddress> & {
-              trackId: string
+              trackId: SequenceTrackId
               position: number
             },
           ) {
@@ -604,7 +613,7 @@ namespace stateEditors {
 
           export function transformKeyframes(
             p: WithoutSheetInstance<SheetObjectAddress> & {
-              trackId: string
+              trackId: SequenceTrackId
               keyframeIds: KeyframeId[]
               translate: number
               scale: number
@@ -633,7 +642,7 @@ namespace stateEditors {
 
           export function deleteKeyframes(
             p: WithoutSheetInstance<SheetObjectAddress> & {
-              trackId: string
+              trackId: SequenceTrackId
               keyframeIds: KeyframeId[]
             },
           ) {
@@ -645,9 +654,9 @@ namespace stateEditors {
             )
           }
 
-          export function replaceKeyframes<T>(
+          export function replaceKeyframes(
             p: WithoutSheetInstance<SheetObjectAddress> & {
-              trackId: string
+              trackId: SequenceTrackId
               keyframes: Array<Keyframe>
               snappingFunction: SnappingFunction
             },

--- a/theatre/studio/src/store/types/ahistoric.ts
+++ b/theatre/studio/src/store/types/ahistoric.ts
@@ -1,5 +1,6 @@
 import type {ProjectState} from '@theatre/core/projects/store/storeTypes'
 import type {Keyframe} from '@theatre/core/projects/store/types/SheetState_Historic'
+import type {ProjectId} from '@theatre/shared/utils/ids'
 import type {IRange, StrictRecord} from '@theatre/shared/utils/types'
 
 export type StudioAhistoricState = {
@@ -50,5 +51,5 @@ export type StudioAhistoricState = {
       }
     >
   }
-  coreByProject: {[projectId in string]: ProjectState['ahistoric']}
+  coreByProject: {[projectId in ProjectId]: ProjectState['ahistoric']}
 }

--- a/theatre/studio/src/uiComponents/simpleContextMenu/ContextMenu/ContextMenu.tsx
+++ b/theatre/studio/src/uiComponents/simpleContextMenu/ContextMenu/ContextMenu.tsx
@@ -18,7 +18,7 @@ const minWidth = 190
  */
 const pointerDistanceThreshold = 20
 
-const Container = styled.ul`
+const MenuContainer = styled.ul`
   position: absolute;
   min-width: ${minWidth}px;
   z-index: 10000;
@@ -34,6 +34,10 @@ const Container = styled.ul`
   border-radius: 3px;
 `
 
+export type IContextMenuItemCustomNodeRenderFn = (controls: {
+  closeMenu(): void
+}) => React.ReactChild
+
 export type IContextMenuItem = {
   label: string | ElementType
   callback?: (e: React.MouseEvent) => void
@@ -41,9 +45,13 @@ export type IContextMenuItem = {
   // subs?: Item[]
 }
 
-const RightClickMenu: React.FC<{
-  items: IContextMenuItem[] | (() => IContextMenuItem[])
-  rightClickPoint: {clientX: number; clientY: number}
+export type IContextMenuItemsValue =
+  | IContextMenuItem[]
+  | (() => IContextMenuItem[])
+
+const ContextMenu: React.FC<{
+  items: IContextMenuItemsValue
+  clickPoint: {clientX: number; clientY: number}
   onRequestClose: () => void
 }> = (props) => {
   const [container, setContainer] = useState<HTMLElement | null>(null)
@@ -59,8 +67,8 @@ const RightClickMenu: React.FC<{
     }
 
     const pos = {
-      left: props.rightClickPoint.clientX - preferredAnchorPoint.left,
-      top: props.rightClickPoint.clientY - preferredAnchorPoint.top,
+      left: props.clickPoint.clientX - preferredAnchorPoint.left,
+      top: props.clickPoint.clientY - preferredAnchorPoint.top,
     }
 
     if (pos.left < 0) {
@@ -94,7 +102,7 @@ const RightClickMenu: React.FC<{
     return () => {
       window.removeEventListener('mousemove', onMouseMove)
     }
-  }, [rect, container, props.rightClickPoint, windowSize, props.onRequestClose])
+  }, [rect, container, props.clickPoint, windowSize, props.onRequestClose])
   const portalLayer = useContext(PortalContext)
 
   useOnKeyDown((ev) => {
@@ -104,7 +112,7 @@ const RightClickMenu: React.FC<{
   const items = Array.isArray(props.items) ? props.items : props.items()
 
   return createPortal(
-    <Container ref={setContainer}>
+    <MenuContainer ref={setContainer}>
       {items.map((item, i) => (
         <Item
           key={`item-${i}`}
@@ -118,9 +126,9 @@ const RightClickMenu: React.FC<{
           }}
         />
       ))}
-    </Container>,
+    </MenuContainer>,
     portalLayer!,
   )
 }
 
-export default RightClickMenu
+export default ContextMenu

--- a/theatre/studio/src/uiComponents/simpleContextMenu/ContextMenu/Item.tsx
+++ b/theatre/studio/src/uiComponents/simpleContextMenu/ContextMenu/Item.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components'
 
 export const height = 26
 
-const Container = styled.li<{enabled: boolean}>`
+const ItemContainer = styled.li<{enabled: boolean}>`
   height: ${height}px;
   padding: 0 12px;
   margin: 0;
@@ -32,7 +32,7 @@ const Container = styled.li<{enabled: boolean}>`
   }
 `
 
-const Label = styled.span``
+const ItemLabel = styled.span``
 
 const Item: React.FC<{
   label: string | ElementType
@@ -40,12 +40,12 @@ const Item: React.FC<{
   enabled: boolean
 }> = (props) => {
   return (
-    <Container
+    <ItemContainer
       onClick={props.enabled ? props.onClick : noop}
       enabled={props.enabled}
     >
-      <Label>{props.label}</Label>
-    </Container>
+      <ItemLabel>{props.label}</ItemLabel>
+    </ItemContainer>
   )
 }
 

--- a/theatre/studio/src/uiComponents/simpleContextMenu/useContextMenu.tsx
+++ b/theatre/studio/src/uiComponents/simpleContextMenu/useContextMenu.tsx
@@ -1,28 +1,36 @@
 import type {VoidFn} from '@theatre/shared/utils/types'
 import React from 'react'
-import RightClickMenu from './RightClickMenu/RightClickMenu'
+import ContextMenu from './ContextMenu/ContextMenu'
+import type {
+  IContextMenuItemsValue,
+  IContextMenuItem,
+} from './ContextMenu/ContextMenu'
 import useRequestContextMenu from './useRequestContextMenu'
-export type {IContextMenuItem} from './RightClickMenu/RightClickMenu'
+import type {IRequestContextMenuOptions} from './useRequestContextMenu'
+
+// re-exports
+export type {
+  IContextMenuItemsValue,
+  IContextMenuItem,
+  IRequestContextMenuOptions,
+}
 
 const emptyNode = <></>
 
-type IProps = Omit<
-  Parameters<typeof RightClickMenu>[0],
-  'rightClickPoint' | 'onRequestClose'
->
-
 export default function useContextMenu(
   target: HTMLElement | SVGElement | null,
-  props: IProps,
+  opts: IRequestContextMenuOptions & {
+    menuItems: IContextMenuItemsValue
+  },
 ): [node: React.ReactNode, close: VoidFn, isOpen: boolean] {
-  const [status, close] = useRequestContextMenu(target)
+  const [status, close] = useRequestContextMenu(target, opts)
 
   const node = !status.isOpen ? (
     emptyNode
   ) : (
-    <RightClickMenu
-      items={props.items}
-      rightClickPoint={status.event}
+    <ContextMenu
+      items={opts.menuItems}
+      clickPoint={status.event}
       onRequestClose={close}
     />
   )

--- a/theatre/studio/src/uiComponents/simpleContextMenu/useRequestContextMenu.ts
+++ b/theatre/studio/src/uiComponents/simpleContextMenu/useRequestContextMenu.ts
@@ -5,28 +5,33 @@ type IState = {isOpen: true; event: MouseEvent} | {isOpen: false}
 
 type CloseMenuFn = () => void
 
+export type IRequestContextMenuOptions = {
+  disabled?: boolean
+}
+
 const useRequestContextMenu = (
   target: HTMLElement | SVGElement | null,
+  opts: IRequestContextMenuOptions,
 ): [state: IState, close: CloseMenuFn] => {
   const [state, setState] = useState<IState>({isOpen: false})
   const close = useCallback<CloseMenuFn>(() => setState({isOpen: false}), [])
 
   useEffect(() => {
-    if (!target) {
+    if (!target || opts.disabled === true) {
       setState({isOpen: false})
       return
     }
 
-    const onContextMenu = (event: MouseEvent) => {
+    const onTrigger = (event: MouseEvent) => {
       setState({isOpen: true, event})
       event.preventDefault()
       event.stopPropagation()
     }
-    target.addEventListener('contextmenu', onContextMenu as $FixMe)
+    target.addEventListener('contextmenu', onTrigger as $FixMe)
     return () => {
-      target.removeEventListener('contextmenu', onContextMenu as $FixMe)
+      target.removeEventListener('contextmenu', onTrigger as $FixMe)
     }
-  }, [target])
+  }, [target, opts.disabled])
 
   return [state, close]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,6 +8,7 @@
     "target": "ESNext",
     "lib": ["es2017", "dom", "ESNext"],
     "isolatedModules": true,
+    "importsNotUsedAsValues": "error",
     "noFallthroughCasesInSwitch": true,
     "jsx": "react",
     "skipLibCheck": true,


### PR DESCRIPTION
See commits list in order.

Commits copied here for clarity:

> dev(tsconfig): ensure imports use `import type ...`
 
> refactor: add pointer types for prop editors 
 
> refactor: Add working Nominal types, clarify identifiers
>  * Use more Nominal types to help with internal code id usage consistency
>  * Broke apart StudioHistoricState type

> doc + optimize: prism.ts (use Maps) 