### PR TITLE
Refactor `useDrag()` and implement middle button dragging

### DIFF
--- a/theatre/studio/src/panels/BasePanel/PanelDragZone.tsx
+++ b/theatre/studio/src/panels/BasePanel/PanelDragZone.tsx
@@ -21,52 +21,44 @@ const PanelDragZone: React.FC<
   const [ref, node] = useRefAndState<HTMLDivElement>(null as $IntentionalAny)
 
   const dragOpts: Parameters<typeof useDrag>[1] = useMemo(() => {
-    let stuffBeforeDrag = panelStuffRef.current
-    let tempTransaction: CommitOrDiscard | undefined
-    let unlock: VoidFn | undefined
     return {
       debugName: 'PanelDragZone',
       lockCursorTo: 'move',
       onDragStart() {
-        stuffBeforeDrag = panelStuffRef.current
-        if (unlock) {
-          const u = unlock
-          unlock = undefined
-          u()
-        }
-        unlock = panelStuff.addBoundsHighlightLock()
-      },
-      onDrag(dx, dy) {
-        const newDims: typeof panelStuff['dims'] = {
-          ...stuffBeforeDrag.dims,
-          top: stuffBeforeDrag.dims.top + dy,
-          left: stuffBeforeDrag.dims.left + dx,
-        }
-        const position = panelDimsToPanelPosition(newDims, {
-          width: window.innerWidth,
-          height: window.innerHeight,
-        })
+        const stuffBeforeDrag = panelStuffRef.current
+        let tempTransaction: CommitOrDiscard | undefined
 
-        tempTransaction?.discard()
-        tempTransaction = getStudio()!.tempTransaction(({stateEditors}) => {
-          stateEditors.studio.historic.panelPositions.setPanelPosition({
-            position,
-            panelId: stuffBeforeDrag.panelId,
-          })
-        })
-      },
-      onDragEnd(dragHappened) {
-        if (unlock) {
-          const u = unlock
-          unlock = undefined
-          u()
+        const unlock = panelStuff.addBoundsHighlightLock()
+
+        return {
+          onDrag(dx, dy) {
+            const newDims: typeof panelStuff['dims'] = {
+              ...stuffBeforeDrag.dims,
+              top: stuffBeforeDrag.dims.top + dy,
+              left: stuffBeforeDrag.dims.left + dx,
+            }
+            const position = panelDimsToPanelPosition(newDims, {
+              width: window.innerWidth,
+              height: window.innerHeight,
+            })
+
+            tempTransaction?.discard()
+            tempTransaction = getStudio()!.tempTransaction(({stateEditors}) => {
+              stateEditors.studio.historic.panelPositions.setPanelPosition({
+                position,
+                panelId: stuffBeforeDrag.panelId,
+              })
+            })
+          },
+          onDragEnd(dragHappened) {
+            unlock()
+            if (dragHappened) {
+              tempTransaction?.commit()
+            } else {
+              tempTransaction?.discard()
+            }
+          },
         }
-        if (dragHappened) {
-          tempTransaction?.commit()
-        } else {
-          tempTransaction?.discard()
-        }
-        tempTransaction = undefined
       },
     }
   }, [])

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/KeyframeEditor/CurveEditorPopover/CurveSegmentEditor.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/KeyframeEditor/CurveEditorPopover/CurveSegmentEditor.tsx
@@ -256,15 +256,17 @@ function useKeyframeDrag(
       lockCursorTo: 'move',
       onDragStart() {
         setFrozen(true)
-      },
-      onDrag(dx, dy) {
-        if (!svgNode) return
+        return {
+          onDrag(dx, dy) {
+            if (!svgNode) return
 
-        props.onCurveChange(setHandles(dx, dy))
-      },
-      onDragEnd(dragHappened) {
-        setFrozen(false)
-        props.onCancelCurveChange()
+            props.onCurveChange(setHandles(dx, dy))
+          },
+          onDragEnd(dragHappened) {
+            setFrozen(false)
+            props.onCancelCurveChange()
+          },
+        }
       },
     }),
     [svgNode, props.trackData],

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/HorizontallyScrollableArea.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/HorizontallyScrollableArea.tsx
@@ -152,23 +152,6 @@ function useHandlePanAndZoom(
     if (!node) return
 
     const receiveWheelEvent = (event: WheelEvent) => {
-      if (Math.abs(event.deltaY) < Math.abs(event.deltaX)) {
-        // receiveVerticalWheelEvent(event)
-        event.preventDefault()
-        event.stopPropagation()
-
-        const scaledSpaceToUnitSpace = val(layoutP.scaledSpace.toUnitSpace)
-        const deltaPos = scaledSpaceToUnitSpace(event.deltaX * 1)
-        const oldRange = val(layoutP.clippedSpace.range)
-        const newRange = mapValues(oldRange, (p) => p + deltaPos)
-
-        const setRange = val(layoutP.clippedSpace.setRange)
-
-        setRange(newRange)
-
-        return
-      }
-
       // pinch
       if (event.ctrlKey) {
         event.preventDefault()
@@ -200,8 +183,9 @@ function useHandlePanAndZoom(
         val(layoutP.clippedSpace.setRange)(
           normalizeRange(newRange, [0, maxEnd]),
         )
+        return
       }
-      // paning
+      // panning
       else if (event.shiftKey) {
         event.preventDefault()
         event.stopPropagation()
@@ -220,6 +204,22 @@ function useHandlePanAndZoom(
         )
 
         val(layoutP.clippedSpace.setRange)(newRange)
+        return
+      } else {
+        receiveVerticalWheelEvent(event)
+        event.preventDefault()
+        event.stopPropagation()
+
+        const scaledSpaceToUnitSpace = val(layoutP.scaledSpace.toUnitSpace)
+        const deltaPos = scaledSpaceToUnitSpace(event.deltaX * 1)
+        const oldRange = val(layoutP.clippedSpace.range)
+        const newRange = mapValues(oldRange, (p) => p + deltaPos)
+
+        const setRange = val(layoutP.clippedSpace.setRange)
+
+        setRange(newRange)
+
+        return
       }
     }
 

--- a/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/BasicKeyframedTrack/KeyframeEditor/CurveHandle.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/GraphEditor/BasicKeyframedTrack/KeyframeEditor/CurveHandle.tsx
@@ -1,10 +1,8 @@
-import type {SequenceEditorPanelLayout} from '@theatre/studio/panels/SequenceEditorPanel/layout/layout'
 import getStudio from '@theatre/studio/getStudio'
 import type {CommitOrDiscard} from '@theatre/studio/StudioStore/StudioStore'
 import useContextMenu from '@theatre/studio/uiComponents/simpleContextMenu/useContextMenu'
 import useDrag from '@theatre/studio/uiComponents/useDrag'
 import useRefAndState from '@theatre/studio/utils/useRefAndState'
-import type {VoidFn} from '@theatre/shared/utils/types'
 import {val} from '@theatre/dataverse'
 import {clamp} from 'lodash-es'
 import React, {useMemo, useRef} from 'react'
@@ -125,115 +123,130 @@ function useOurDrags(node: SVGCircleElement | null, props: IProps): void {
   propsRef.current = props
 
   const handlers = useMemo<Parameters<typeof useDrag>[1]>(() => {
-    let scaledToUnitSpace: SequenceEditorPanelLayout['scaledSpace']['toUnitSpace']
-    let verticalToExtremumSpace: SequenceEditorPanelLayout['graphEditorVerticalSpace']['toExtremumSpace']
-    let propsAtStartOfDrag: IProps
-    let tempTransaction: CommitOrDiscard | undefined
-    let unlockExtremums: VoidFn | undefined
     return {
       debugName: 'CurveHandler/useOurDrags',
       lockCursorTo: 'move',
       onDragStart() {
-        propsAtStartOfDrag = propsRef.current
+        let tempTransaction: CommitOrDiscard | undefined
 
-        scaledToUnitSpace = val(
+        const propsAtStartOfDrag = propsRef.current
+
+        const scaledToUnitSpace = val(
           propsAtStartOfDrag.layoutP.scaledSpace.toUnitSpace,
         )
-        verticalToExtremumSpace = val(
+        const verticalToExtremumSpace = val(
           propsAtStartOfDrag.layoutP.graphEditorVerticalSpace.toExtremumSpace,
         )
 
-        unlockExtremums = propsAtStartOfDrag.extremumSpace.lock()
-      },
-      onDrag(dxInScaledSpace, dy) {
-        if (tempTransaction) {
-          tempTransaction.discard()
-          tempTransaction = undefined
+        const unlockExtremums = propsAtStartOfDrag.extremumSpace.lock()
+
+        return {
+          onDrag(dxInScaledSpace, dy) {
+            if (tempTransaction) {
+              tempTransaction.discard()
+              tempTransaction = undefined
+            }
+
+            const {index, trackData} = propsAtStartOfDrag
+            const cur = trackData.keyframes[index]
+            const next = trackData.keyframes[index + 1]
+
+            const dPosInUnitSpace = scaledToUnitSpace(dxInScaledSpace)
+            let dPosInKeyframeDiffSpace =
+              dPosInUnitSpace / (next.position - cur.position)
+
+            const dyInVerticalSpace = -dy
+            const dYInExtremumSpace = verticalToExtremumSpace(dyInVerticalSpace)
+
+            const dYInValueSpace =
+              propsAtStartOfDrag.extremumSpace.deltaToValueSpace(
+                dYInExtremumSpace,
+              )
+
+            const curValue = props.isScalar ? (cur.value as number) : 0
+            const nextValue = props.isScalar ? (next.value as number) : 1
+            const dyInKeyframeDiffSpace =
+              dYInValueSpace / (nextValue - curValue)
+
+            if (propsAtStartOfDrag.which === 'left') {
+              const handleX = clamp(
+                cur.handles[2] + dPosInKeyframeDiffSpace,
+                0,
+                1,
+              )
+              const handleY = cur.handles[3] + dyInKeyframeDiffSpace
+
+              tempTransaction = getStudio()!.tempTransaction(
+                ({stateEditors}) => {
+                  stateEditors.coreByProject.historic.sheetsById.sequence.replaceKeyframes(
+                    {
+                      ...propsAtStartOfDrag.sheetObject.address,
+                      snappingFunction: val(
+                        propsAtStartOfDrag.layoutP.sheet,
+                      ).getSequence().closestGridPosition,
+                      trackId: propsAtStartOfDrag.trackId,
+                      keyframes: [
+                        {
+                          ...cur,
+                          handles: [
+                            cur.handles[0],
+                            cur.handles[1],
+                            handleX,
+                            handleY,
+                          ],
+                        },
+                      ],
+                    },
+                  )
+                },
+              )
+            } else {
+              const handleX = clamp(
+                next.handles[0] + dPosInKeyframeDiffSpace,
+                0,
+                1,
+              )
+              const handleY = next.handles[1] + dyInKeyframeDiffSpace
+
+              tempTransaction = getStudio()!.tempTransaction(
+                ({stateEditors}) => {
+                  stateEditors.coreByProject.historic.sheetsById.sequence.replaceKeyframes(
+                    {
+                      ...propsAtStartOfDrag.sheetObject.address,
+                      trackId: propsAtStartOfDrag.trackId,
+                      snappingFunction: val(
+                        propsAtStartOfDrag.layoutP.sheet,
+                      ).getSequence().closestGridPosition,
+                      keyframes: [
+                        {
+                          ...next,
+                          handles: [
+                            handleX,
+                            handleY,
+                            next.handles[2],
+                            next.handles[3],
+                          ],
+                        },
+                      ],
+                    },
+                  )
+                },
+              )
+            }
+          },
+          onDragEnd(dragHappened) {
+            unlockExtremums()
+            if (dragHappened) {
+              if (tempTransaction) {
+                tempTransaction.commit()
+              }
+            } else {
+              if (tempTransaction) {
+                tempTransaction.discard()
+              }
+            }
+          },
         }
-
-        const {index, trackData} = propsAtStartOfDrag
-        const cur = trackData.keyframes[index]
-        const next = trackData.keyframes[index + 1]
-
-        const dPosInUnitSpace = scaledToUnitSpace(dxInScaledSpace)
-        let dPosInKeyframeDiffSpace =
-          dPosInUnitSpace / (next.position - cur.position)
-
-        const dyInVerticalSpace = -dy
-        const dYInExtremumSpace = verticalToExtremumSpace(dyInVerticalSpace)
-
-        const dYInValueSpace =
-          propsAtStartOfDrag.extremumSpace.deltaToValueSpace(dYInExtremumSpace)
-
-        const curValue = props.isScalar ? (cur.value as number) : 0
-        const nextValue = props.isScalar ? (next.value as number) : 1
-        const dyInKeyframeDiffSpace = dYInValueSpace / (nextValue - curValue)
-
-        if (propsAtStartOfDrag.which === 'left') {
-          const handleX = clamp(cur.handles[2] + dPosInKeyframeDiffSpace, 0, 1)
-          const handleY = cur.handles[3] + dyInKeyframeDiffSpace
-
-          tempTransaction = getStudio()!.tempTransaction(({stateEditors}) => {
-            stateEditors.coreByProject.historic.sheetsById.sequence.replaceKeyframes(
-              {
-                ...propsAtStartOfDrag.sheetObject.address,
-                snappingFunction: val(
-                  propsAtStartOfDrag.layoutP.sheet,
-                ).getSequence().closestGridPosition,
-                trackId: propsAtStartOfDrag.trackId,
-                keyframes: [
-                  {
-                    ...cur,
-                    handles: [cur.handles[0], cur.handles[1], handleX, handleY],
-                  },
-                ],
-              },
-            )
-          })
-        } else {
-          const handleX = clamp(next.handles[0] + dPosInKeyframeDiffSpace, 0, 1)
-          const handleY = next.handles[1] + dyInKeyframeDiffSpace
-
-          tempTransaction = getStudio()!.tempTransaction(({stateEditors}) => {
-            stateEditors.coreByProject.historic.sheetsById.sequence.replaceKeyframes(
-              {
-                ...propsAtStartOfDrag.sheetObject.address,
-                trackId: propsAtStartOfDrag.trackId,
-                snappingFunction: val(
-                  propsAtStartOfDrag.layoutP.sheet,
-                ).getSequence().closestGridPosition,
-                keyframes: [
-                  {
-                    ...next,
-                    handles: [
-                      handleX,
-                      handleY,
-                      next.handles[2],
-                      next.handles[3],
-                    ],
-                  },
-                ],
-              },
-            )
-          })
-        }
-      },
-      onDragEnd(dragHappened) {
-        if (unlockExtremums) {
-          const unlock = unlockExtremums
-          unlockExtremums = undefined
-          unlock()
-        }
-        if (dragHappened) {
-          if (tempTransaction) {
-            tempTransaction.commit()
-          }
-        } else {
-          if (tempTransaction) {
-            tempTransaction.discard()
-          }
-        }
-        tempTransaction = undefined
       },
     }
   }, [])

--- a/theatre/studio/src/panels/SequenceEditorPanel/RightOverlay/Playhead.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/RightOverlay/Playhead.tsx
@@ -1,4 +1,3 @@
-import type Sequence from '@theatre/core/sequences/Sequence'
 import type {SequenceEditorPanelLayout} from '@theatre/studio/panels/SequenceEditorPanel/layout/layout'
 import RoomToClick from '@theatre/studio/uiComponents/RoomToClick'
 import useDrag from '@theatre/studio/uiComponents/useDrag'
@@ -203,32 +202,31 @@ const Playhead: React.FC<{layoutP: Pointer<SequenceEditorPanelLayout>}> = ({
   )
 
   const gestureHandlers = useMemo((): Parameters<typeof useDrag>[1] => {
-    const setIsSeeking = val(layoutP.seeker.setIsSeeking)
-
-    let posBeforeSeek = 0
-    let sequence: Sequence
-    let scaledSpaceToUnitSpace: typeof layoutP.scaledSpace.toUnitSpace.$$__pointer_type
-
     return {
       debugName: 'Playhead',
       onDragStart() {
-        sequence = val(layoutP.sheet).getSequence()
-        posBeforeSeek = sequence.position
-        scaledSpaceToUnitSpace = val(layoutP.scaledSpace.toUnitSpace)
-        setIsSeeking(true)
-      },
-      onDrag(dx, _, event) {
-        const deltaPos = scaledSpaceToUnitSpace(dx)
+        const setIsSeeking = val(layoutP.seeker.setIsSeeking)
 
-        sequence.position =
-          DopeSnap.checkIfMouseEventSnapToPos(event, {
-            ignore: thumbNode,
-          }) ??
-          // unsnapped
-          clamp(posBeforeSeek + deltaPos, 0, sequence.length)
-      },
-      onDragEnd() {
-        setIsSeeking(false)
+        const sequence = val(layoutP.sheet).getSequence()
+        const posBeforeSeek = sequence.position
+        const scaledSpaceToUnitSpace = val(layoutP.scaledSpace.toUnitSpace)
+        setIsSeeking(true)
+
+        return {
+          onDrag(dx, _, event) {
+            const deltaPos = scaledSpaceToUnitSpace(dx)
+
+            sequence.position =
+              DopeSnap.checkIfMouseEventSnapToPos(event, {
+                ignore: thumbNode,
+              }) ??
+              // unsnapped
+              clamp(posBeforeSeek + deltaPos, 0, sequence.length)
+          },
+          onDragEnd() {
+            setIsSeeking(false)
+          },
+        }
       },
     }
   }, [])

--- a/theatre/studio/src/panels/SequenceEditorPanel/VerticalScrollContainer.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/VerticalScrollContainer.tsx
@@ -20,19 +20,29 @@ const Container = styled.div`
   scrollbar-width: none;
 `
 
-type ReceiveVerticalWheelEventFn = (ev: WheelEvent) => void
+type ReceiveVerticalWheelEventFn = (ev: Pick<WheelEvent, 'deltaY'>) => void
 
 const ctx = createContext<ReceiveVerticalWheelEventFn>(voidFn)
+
+/**
+ * See {@link VerticalScrollContainer} and references for how to use this.
+ */
 export const useReceiveVerticalWheelEvent = (): ReceiveVerticalWheelEventFn =>
   useContext(ctx)
 
+/**
+ * This is used in the sequence editor where we block wheel events to handle
+ * pan/zoom on the time axis. The issue this solves, is that when blocking those
+ * wheel events, we prevent the vertical scroll events from being fired. This container
+ * comes with a context and a hook (see {@link useReceiveVerticalWheelEvent}) that allows
+ * the code that traps the wheel events to pass them to the vertical scroller root, which
+ * we then use to manually dispatch scroll events.
+ */
 const VerticalScrollContainer: React.FC<{}> = (props) => {
   const ref = useRef<HTMLDivElement | null>(null)
   const receiveVerticalWheelEvent = useCallback<ReceiveVerticalWheelEventFn>(
-    (event: WheelEvent) => {
-      // const ev = new WheelEvent('wheel', {deltaY: event.deltaY})
-      // ref.current!.scrollBy(0, event.deltaY)
-      // ref.current!.dispatchEvent(ev)
+    (event) => {
+      ref.current!.scrollBy(0, event.deltaY)
     },
     [],
   )

--- a/theatre/studio/src/uiComponents/useDrag.ts
+++ b/theatre/studio/src/uiComponents/useDrag.ts
@@ -4,6 +4,28 @@ import useRefAndState from '@theatre/studio/utils/useRefAndState'
 import {useCssCursorLock} from './PointerEventsHandler'
 import type {CapturedPointer} from '@theatre/studio/UIRoot/PointerCapturing'
 import {usePointerCapturing} from '@theatre/studio/UIRoot/PointerCapturing'
+import noop from '@theatre/shared/utils/noop'
+
+export enum MouseButton {
+  Left = 0,
+  Middle = 1,
+  // Not including Right because it _might_ interfere with chord clicking.
+  // So we'll wait for chord-clicking to land before exploring right-button gestures
+}
+
+/**
+ * dx, dy: delta x/y from the start of the drag
+ */
+type OnDragCallback = (
+  // deltaX/Y are counted from the start of the drag
+  deltaX: number,
+  deltaY: number,
+  event: MouseEvent,
+  dxFromLastEvent: number,
+  dyFromLastEvent: number,
+) => void
+
+type OnDragEndCallback = (dragHappened: boolean) => void
 
 export type UseDragOpts = {
   /**
@@ -35,22 +57,23 @@ export type UseDragOpts = {
    * onDragStart can be undefined, in which case, we always handle useDrag,
    * but when defined, we can allow the handler to return false to indicate ignore this dragging
    */
-  onDragStart?: (event: MouseEvent) => void | false
-  /**
-   * Called at the end of the drag gesture.
-   * `dragHappened` will be `true` if the user actually moved the pointer
-   * (if onDrag isn't called, then this will be false becuase the user hasn't moved the pointer)
-   */
-  onDragEnd?: (dragHappened: boolean) => void
-  /**
-   * This will be called 0 times if the gesture ends up being a click,
-   * or 1 or more times if it ends up being a drag gesture.
-   *
-   * `dx`: the delta x
-   * `dy`: the delta y
-   * `event`: the mouse event
-   */
-  onDrag: (dx: number, dy: number, event: MouseEvent) => void
+  onDragStart: (event: MouseEvent) =>
+    | false
+    | {
+        /**
+         * Called at the end of the drag gesture.
+         * `dragHappened` will be `true` if the user actually moved the pointer
+         * (if onDrag isn't called, then this will be false becuase the user hasn't moved the pointer)
+         */
+        onDragEnd?: OnDragEndCallback
+        onDrag: OnDragCallback
+      }
+
+  // which mouse button to use the drag event
+  buttons?:
+    | [MouseButton]
+    | [MouseButton, MouseButton]
+    | [MouseButton | MouseButton | MouseButton]
 }
 
 export default function useDrag(
@@ -80,9 +103,15 @@ export default function useDrag(
     }
   }>({dragHappened: false, startPos: {x: 0, y: 0}})
 
+  const callbacksRef = useRef<{
+    onDrag: OnDragCallback
+    onDragEnd: OnDragEndCallback
+  }>({onDrag: noop, onDragEnd: noop})
+
   const capturedPointerRef = useRef<undefined | CapturedPointer>()
   useLayoutEffect(() => {
     if (!target) return
+    let lastDeltas = [0, 0]
 
     const getDistances = (event: MouseEvent): [number, number] => {
       const {startPos} = stateRef.current
@@ -94,14 +123,26 @@ export default function useDrag(
       modeRef.current = 'dragging'
 
       const deltas = getDistances(event)
-      optsRef.current.onDrag(deltas[0], deltas[1], event)
+      const [deltaFromLastX, deltaFromLastY] = [
+        deltas[0] - lastDeltas[0],
+        deltas[1] - lastDeltas[1],
+      ]
+      lastDeltas = deltas
+
+      callbacksRef.current.onDrag(
+        deltas[0],
+        deltas[1],
+        event,
+        deltaFromLastX,
+        deltaFromLastY,
+      )
     }
 
     const dragEndHandler = () => {
       removeDragListeners()
       modeRef.current = 'notDragging'
 
-      optsRef.current.onDragEnd?.(stateRef.current.dragHappened)
+      callbacksRef.current.onDragEnd(stateRef.current.dragHappened)
     }
 
     const addDragListeners = () => {
@@ -136,13 +177,18 @@ export default function useDrag(
       const opts = optsRef.current
       if (opts.disabled === true) return
 
-      if (event.button !== 0) return
+      const acceptedButtons: MouseButton[] = opts.buttons ?? [MouseButton.Left]
 
-      // onDragStart can be undefined, in which case, we always handle useDrag,
-      // but when defined, we can allow the handler to return false to indicate ignore this dragging
-      if (opts.onDragStart != null) {
-        const shouldIgnore = opts.onDragStart(event) === false
-        if (shouldIgnore) return
+      if (!acceptedButtons.includes(event.button)) return
+
+      const returnOfOnDragStart = opts.onDragStart(event)
+
+      if (returnOfOnDragStart === false) {
+        // we should ignore the gesture
+        return
+      } else {
+        callbacksRef.current.onDrag = returnOfOnDragStart.onDrag
+        callbacksRef.current.onDragEnd = returnOfOnDragStart.onDragEnd ?? noop
       }
 
       // need to capture pointer after we know the provided handler wants to handle drag start
@@ -175,7 +221,7 @@ export default function useDrag(
       target.removeEventListener('click', preventUnwantedClick as $FixMe)
 
       if (modeRef.current !== 'notDragging') {
-        optsRef.current.onDragEnd?.(modeRef.current === 'dragging')
+        callbacksRef.current.onDragEnd?.(modeRef.current === 'dragging')
       }
       modeRef.current = 'notDragging'
     }


### PR DESCRIPTION
This PR simplifies `useDrag()`'s API, and fixes various scrolling issues on windows, mainly the bug that appears when scrolling small amounts via mouse/trackpad would cause SequenceEditor's horizontal scroll to drift without actually updating the clipped space range.