### PR TITLE
Single tween editor for aggregate rows

### DIFF
--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/AggregatedKeyframeTrack/AggregateKeyframeEditor.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/AggregatedKeyframeTrack/AggregateKeyframeEditor.tsx
@@ -75,6 +75,19 @@ export type IAggregateKeyframeEditorProps = {
   selection: undefined | DopeSheetSelection
 }
 
+/**
+ * TODO we're spending a lot of cycles on each render of each aggreagte keyframes.
+ *
+ * Each keyframe node is doing O(N) operations, N being the number of underlying
+ * keyframes it represetns.
+ *
+ * The biggest example is the `isConnectionEditingInCurvePopover()` call which is run
+ * for every underlying keyframe, every time this component is rendered.
+ *
+ * We can optimize this away by doing all of this work _once_ when a curve editor popover
+ * is open. This would require having some kind of stable identity for each aggregate row.
+ * Let's defer that work until other interactive keyframe editing PRs are merged in.
+ */
 const AggregateKeyframeEditor: React.VFC<IAggregateKeyframeEditorProps> = (
   props,
 ) => {

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/KeyframeEditor/BasicKeyframeConnector.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/KeyframeEditor/BasicKeyframeConnector.tsx
@@ -9,7 +9,7 @@ import {useMemo, useRef} from 'react'
 import usePopover from '@theatre/studio/uiComponents/Popover/usePopover'
 import BasicPopover from '@theatre/studio/uiComponents/Popover/BasicPopover'
 import CurveEditorPopover, {
-  isConnectionEditingInCurvePopoverD,
+  isConnectionEditingInCurvePopover,
 } from './CurveEditorPopover/CurveEditorPopover'
 import selectedKeyframeIdsIfInSingleTrack from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/selectedKeyframeIdsIfInSingleTrack'
 import type {OpenFn} from '@theatre/studio/src/uiComponents/Popover/usePopover'
@@ -19,7 +19,7 @@ import type {ISingleKeyframeEditorProps} from './SingleKeyframeEditor'
 import type {IConnectorThemeValues} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/keyframeRowUI/ConnectorLine'
 import {ConnectorLine} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/keyframeRowUI/ConnectorLine'
 import {COLOR_POPOVER_BACK} from './CurveEditorPopover/colors'
-import {useVal} from '@theatre/react'
+import {usePrism} from '@theatre/react'
 import type {KeyframeConnectionWithAddress} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/selections'
 import {selectedKeyframeConnections} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/selections'
 
@@ -94,13 +94,15 @@ const BasicKeyframeConnector: React.VFC<IBasicKeyframeConnectorProps> = (
 
   const connectorLengthInUnitSpace = next.position - cur.position
 
-  const isInCurveEditorPopoverSelection = useVal(
-    isConnectionEditingInCurvePopoverD({
-      ...props.leaf.sheetObject.address,
-      trackId: props.leaf.trackId,
-      left: cur,
-      right: next,
-    }),
+  const isInCurveEditorPopoverSelection = usePrism(
+    () =>
+      isConnectionEditingInCurvePopover({
+        ...props.leaf.sheetObject.address,
+        trackId: props.leaf.trackId,
+        left: cur,
+        right: next,
+      }),
+    [props.leaf.sheetObject.address, props.leaf.trackId, cur, next],
   )
 
   const themeValues: IConnectorThemeValues = {

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/KeyframeEditor/BasicKeyframeConnector.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/KeyframeEditor/BasicKeyframeConnector.tsx
@@ -9,7 +9,7 @@ import {useMemo, useRef} from 'react'
 import usePopover from '@theatre/studio/uiComponents/Popover/usePopover'
 import BasicPopover from '@theatre/studio/uiComponents/Popover/BasicPopover'
 import CurveEditorPopover, {
-  isCurveEditorOpenD,
+  isConnectionEditingInCurvePopoverD,
 } from './CurveEditorPopover/CurveEditorPopover'
 import selectedKeyframeIdsIfInSingleTrack from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/selectedKeyframeIdsIfInSingleTrack'
 import type {OpenFn} from '@theatre/studio/src/uiComponents/Popover/usePopover'
@@ -21,10 +21,7 @@ import {ConnectorLine} from '@theatre/studio/panels/SequenceEditorPanel/DopeShee
 import {COLOR_POPOVER_BACK} from './CurveEditorPopover/colors'
 import {useVal} from '@theatre/react'
 import type {KeyframeConnectionWithAddress} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/selections'
-import {
-  isKeyframeConnectionInSelection,
-  selectedKeyframeConnections,
-} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/selections'
+import {selectedKeyframeConnections} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/selections'
 
 import styled from 'styled-components'
 
@@ -97,18 +94,18 @@ const BasicKeyframeConnector: React.VFC<IBasicKeyframeConnectorProps> = (
 
   const connectorLengthInUnitSpace = next.position - cur.position
 
-  // The following two flags determine whether this connector
-  // is being edited as part of a selection using the curve
-  // editor popover
-  const isCurveEditorPopoverOpen = useVal(isCurveEditorOpenD)
-  const isInCurveEditorPopoverSelection =
-    isCurveEditorPopoverOpen &&
-    props.selection !== undefined &&
-    isKeyframeConnectionInSelection({left: cur, right: next}, props.selection)
+  const isInCurveEditorPopoverSelection = useVal(
+    isConnectionEditingInCurvePopoverD({
+      ...props.leaf.sheetObject.address,
+      trackId: props.leaf.trackId,
+      left: cur,
+      right: next,
+    }),
+  )
 
   const themeValues: IConnectorThemeValues = {
-    isPopoverOpen: isPopoverOpen || isInCurveEditorPopoverSelection || false,
-    isSelected: !!props.selection,
+    isPopoverOpen: isInCurveEditorPopoverSelection,
+    isSelected: props.selection !== undefined,
   }
 
   return (

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/KeyframeEditor/CurveEditorPopover/CurveEditorPopover.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/KeyframeEditor/CurveEditorPopover/CurveEditorPopover.tsx
@@ -489,7 +489,7 @@ function areConnectedKeyframesTheSameAs({
     right1.handles[1] !== right2.handles[1]
 }
 
-const {isCurveEditorOpenD, isConnectionEditingInCurvePopoverD, getLock} =
+const {isCurveEditorOpenD, isConnectionEditingInCurvePopover, getLock} =
   (() => {
     const connectionsInCurvePopoverEdit = new Box<
       Array<KeyframeConnectionWithAddress>
@@ -506,18 +506,17 @@ const {isCurveEditorOpenD, isConnectionEditingInCurvePopoverD, getLock} =
       isCurveEditorOpenD: prism(() => {
         return connectionsInCurvePopoverEdit.derivation.getValue().length > 0
       }),
-      isConnectionEditingInCurvePopoverD: (
-        con: KeyframeConnectionWithAddress,
-      ) =>
-        prism(() => {
-          return connectionsInCurvePopoverEdit.derivation
-            .getValue()
-            .some(
-              ({left, right}) =>
-                con.left.id === left.id && con.right.id === right.id,
-            )
-        }),
+      // must be run in a prism
+      isConnectionEditingInCurvePopover(con: KeyframeConnectionWithAddress) {
+        prism.ensurePrism()
+        return connectionsInCurvePopoverEdit.derivation
+          .getValue()
+          .some(
+            ({left, right}) =>
+              con.left.id === left.id && con.right.id === right.id,
+          )
+      },
     }
   })()
 
-export {isCurveEditorOpenD, isConnectionEditingInCurvePopoverD}
+export {isCurveEditorOpenD, isConnectionEditingInCurvePopover}

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/KeyframeEditor/CurveEditorPopover/CurveSegmentEditor.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/KeyframeEditor/CurveEditorPopover/CurveSegmentEditor.tsx
@@ -91,6 +91,7 @@ const CurveSegmentEditor: React.VFC<ICurveSegmentEditorProps> = (props) => {
 
   const [refLeft, nodeLeft] = useRefAndState<SVGCircleElement | null>(null)
   useKeyframeDrag(nodeSVG, nodeLeft, props, (dx, dy) => {
+    // TODO - document this
     const handleX = clamp(left.handles[2] + dx * viewboxToElWidthRatio, 0, 1)
     const handleY = left.handles[3] - dy * viewboxToElHeightRatio
     return [handleX, handleY, right.handles[0], right.handles[1]]
@@ -98,6 +99,7 @@ const CurveSegmentEditor: React.VFC<ICurveSegmentEditorProps> = (props) => {
 
   const [refRight, nodeRight] = useRefAndState<SVGCircleElement | null>(null)
   useKeyframeDrag(nodeSVG, nodeRight, props, (dx, dy) => {
+    // TODO - document this
     const handleX = clamp(right.handles[0] + dx * viewboxToElWidthRatio, 0, 1)
     const handleY = right.handles[1] - dy * viewboxToElHeightRatio
     return [left.handles[2], left.handles[3], handleX, handleY]
@@ -289,7 +291,7 @@ function useKeyframeDrag(
         }
       },
     }),
-    [svgNode, props],
+    [svgNode, props.onCurveChange, props.onCancelCurveChange],
   )
 
   useDrag(node, handlers)

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/KeyframeEditor/CurveEditorPopover/CurveSegmentEditor.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/KeyframeEditor/CurveEditorPopover/CurveSegmentEditor.tsx
@@ -2,12 +2,12 @@ import React from 'react'
 import useDrag from '@theatre/studio/uiComponents/useDrag'
 import useRefAndState from '@theatre/studio/utils/useRefAndState'
 import clamp from 'lodash-es/clamp'
-import type CurveEditorPopover from './CurveEditorPopover'
 import styled from 'styled-components'
 import {pointerEventsAutoInNormalMode} from '@theatre/studio/css'
 import type {CubicBezierHandles} from './shared'
 import {useFreezableMemo} from './useFreezableMemo'
 import {COLOR_BASE} from './colors'
+import type {KeyframeConnectionWithAddress} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/selections'
 
 // Defines the dimensions of the SVG viewbox space
 const VIEWBOX_PADDING = 0.12
@@ -29,6 +29,13 @@ const CURVE_END_OVERSHOOT_COLOR = '#3EAAA4'
 const CONTROL_COLOR = '#B3B3B3'
 const HANDLE_COLOR = '#3eaaa4'
 const HANDLE_HOVER_COLOR = '#67dfd8'
+
+const BACKGROUND_CURVE_COLORS = [
+  'goldenrod',
+  'cornflowerblue',
+  'dodgerblue',
+  'lawngreen',
+]
 
 const Circle = styled.circle`
   stroke-width: 0.1px;
@@ -53,23 +60,26 @@ const HitZone = styled.circle`
   }
 `
 
-type IProps = {
+type ICurveSegmentEditorProps = {
   onCurveChange: (newHandles: CubicBezierHandles) => void
   onCancelCurveChange: () => void
-} & Parameters<typeof CurveEditorPopover>[0]
+  curveConnection: KeyframeConnectionWithAddress
+  backgroundConnections: Array<KeyframeConnectionWithAddress>
+}
 
-const CurveSegmentEditor: React.FC<IProps> = (props) => {
-  const {index, trackData} = props
-  const cur = trackData.keyframes[index]
-  const next = trackData.keyframes[index + 1]
-
+const CurveSegmentEditor: React.VFC<ICurveSegmentEditorProps> = (props) => {
+  const {
+    curveConnection,
+    curveConnection: {left, right},
+    backgroundConnections,
+  } = props
   // Calculations towards keeping the handles in the viewbox. The extremum space
   // of this editor vertically scales to keep the handles in the viewbox of the
   // SVG. This produces a nice "stretching space" effect while you are dragging
   // the handles.
   // Demo: https://user-images.githubusercontent.com/11082236/164542544-f1f66de2-f62e-44dd-b4cb-05b5f6e73a52.mp4
-  const minY = Math.min(0, 1 - next.handles[1], 1 - cur.handles[3])
-  const maxY = Math.max(1, 1 - next.handles[1], 1 - cur.handles[3])
+  const minY = Math.min(0, 1 - right.handles[1], 1 - left.handles[3])
+  const maxY = Math.max(1, 1 - right.handles[1], 1 - left.handles[3])
   const h = Math.max(1, maxY - minY)
 
   const toExtremumSpace = (y: number) => (y - minY) / h
@@ -81,26 +91,24 @@ const CurveSegmentEditor: React.FC<IProps> = (props) => {
 
   const [refLeft, nodeLeft] = useRefAndState<SVGCircleElement | null>(null)
   useKeyframeDrag(nodeSVG, nodeLeft, props, (dx, dy) => {
-    const handleX = clamp(cur.handles[2] + dx * viewboxToElWidthRatio, 0, 1)
-    const handleY = cur.handles[3] - dy * viewboxToElHeightRatio
-
-    return [handleX, handleY, next.handles[0], next.handles[1]]
+    const handleX = clamp(left.handles[2] + dx * viewboxToElWidthRatio, 0, 1)
+    const handleY = left.handles[3] - dy * viewboxToElHeightRatio
+    return [handleX, handleY, right.handles[0], right.handles[1]]
   })
 
   const [refRight, nodeRight] = useRefAndState<SVGCircleElement | null>(null)
   useKeyframeDrag(nodeSVG, nodeRight, props, (dx, dy) => {
-    const handleX = clamp(next.handles[0] + dx * viewboxToElWidthRatio, 0, 1)
-    const handleY = next.handles[1] - dy * viewboxToElHeightRatio
-
-    return [cur.handles[2], cur.handles[3], handleX, handleY]
+    const handleX = clamp(right.handles[0] + dx * viewboxToElWidthRatio, 0, 1)
+    const handleY = right.handles[1] - dy * viewboxToElHeightRatio
+    return [left.handles[2], left.handles[3], handleX, handleY]
   })
 
-  const curvePathDAttrValue = `M0 ${toExtremumSpace(1)} C${
-    cur.handles[2]
-  } ${toExtremumSpace(1 - cur.handles[3])} 
-${next.handles[0]} ${toExtremumSpace(1 - next.handles[1])} 1 ${toExtremumSpace(
-    0,
-  )}`
+  const curvePathDAttrValue = (connection: KeyframeConnectionWithAddress) =>
+    `M0 ${toExtremumSpace(1)} C${connection.left.handles[2]} ${toExtremumSpace(
+      1 - connection.left.handles[3],
+    )} ${connection.right.handles[0]} ${toExtremumSpace(
+      1 - connection.right.handles[1],
+    )} 1 ${toExtremumSpace(0)}`
 
   return (
     <svg
@@ -173,8 +181,8 @@ ${next.handles[0]} ${toExtremumSpace(1 - next.handles[1])} 1 ${toExtremumSpace(
       <line
         x1={0}
         y1={toExtremumSpace(1)}
-        x2={cur.handles[2]}
-        y2={toExtremumSpace(1 - cur.handles[3])}
+        x2={left.handles[2]}
+        y2={toExtremumSpace(1 - left.handles[3])}
         stroke={CONTROL_COLOR}
         strokeWidth="0.01"
       />
@@ -182,26 +190,35 @@ ${next.handles[0]} ${toExtremumSpace(1 - next.handles[1])} 1 ${toExtremumSpace(
       <line
         x1={1}
         y1={toExtremumSpace(0)}
-        x2={next.handles[0]}
-        y2={toExtremumSpace(1 - next.handles[1])}
+        x2={right.handles[0]}
+        y2={toExtremumSpace(1 - right.handles[1])}
         stroke={CONTROL_COLOR}
         strokeWidth="0.01"
       />
 
       {/* Curve "shadow": the low-opacity filled area between the curve and the diagonal */}
       <path
-        d={curvePathDAttrValue}
+        d={curvePathDAttrValue(props.curveConnection)}
         stroke="none"
         fill="url('#myGradient')"
         opacity="0.1"
       />
+      {/* The background curves (e.g. multiple different values) */}
+      {backgroundConnections.map((connection, i) => (
+        <path
+          key={connection.objectKey + '/' + connection.left.id}
+          d={curvePathDAttrValue(connection)}
+          stroke={BACKGROUND_CURVE_COLORS[i % BACKGROUND_CURVE_COLORS.length]}
+          opacity={0.6}
+          strokeWidth="0.01"
+        />
+      ))}
       {/* The curve */}
       <path
-        d={curvePathDAttrValue}
+        d={curvePathDAttrValue(props.curveConnection)}
         stroke="url('#myGradient')"
         strokeWidth="0.02"
       />
-
       {/* Right end of curve */}
       <circle
         cx={0}
@@ -224,21 +241,24 @@ ${next.handles[0]} ${toExtremumSpace(1 - next.handles[1])} 1 ${toExtremumSpace(
       {/* Right handle and hit zone */}
       <HitZone
         ref={refLeft}
-        cx={cur.handles[2]}
-        cy={toExtremumSpace(1 - cur.handles[3])}
+        cx={left.handles[2]}
+        cy={toExtremumSpace(1 - left.handles[3])}
         fill={CURVE_START_COLOR}
         opacity={0.2}
       />
-      <Circle cx={cur.handles[2]} cy={toExtremumSpace(1 - cur.handles[3])} />
+      <Circle cx={left.handles[2]} cy={toExtremumSpace(1 - left.handles[3])} />
       {/* Left handle and hit zone */}
       <HitZone
         ref={refRight}
-        cx={next.handles[0]}
-        cy={toExtremumSpace(1 - next.handles[1])}
+        cx={right.handles[0]}
+        cy={toExtremumSpace(1 - right.handles[1])}
         fill={CURVE_END_COLOR}
         opacity={0.2}
       />
-      <Circle cx={next.handles[0]} cy={toExtremumSpace(1 - next.handles[1])} />
+      <Circle
+        cx={right.handles[0]}
+        cy={toExtremumSpace(1 - right.handles[1])}
+      />
     </svg>
   )
 }
@@ -247,7 +267,7 @@ export default CurveSegmentEditor
 function useKeyframeDrag(
   svgNode: SVGSVGElement | null,
   node: SVGCircleElement | null,
-  props: IProps,
+  props: ICurveSegmentEditorProps,
   setHandles: (dx: number, dy: number) => CubicBezierHandles,
 ): void {
   const handlers = useFreezableMemo<Parameters<typeof useDrag>[1]>(
@@ -269,7 +289,7 @@ function useKeyframeDrag(
         }
       },
     }),
-    [svgNode, props.trackData],
+    [svgNode, props],
   )
 
   useDrag(node, handlers)

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/keyframeRowUI/ConnectorLine.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/keyframeRowUI/ConnectorLine.tsx
@@ -57,8 +57,6 @@ const Container = styled.div<IConnectorThemeValues>`
 
 type IConnectorLineProps = React.PropsWithChildren<{
   isPopoverOpen: boolean
-  /** TEMP: Remove once interactivity is added for aggregate? */
-  mvpIsInteractiveDisabled?: boolean
   openPopover?: (event: React.MouseEvent) => void
   isSelected: boolean
   connectorLengthInUnitSpace: number
@@ -82,7 +80,6 @@ export const ConnectorLine = React.forwardRef<
         transform: `scaleX(calc(var(--unitSpaceToScaledSpaceMultiplier) * ${
           props.connectorLengthInUnitSpace / CONNECTOR_WIDTH_UNSCALED
         }))`,
-        pointerEvents: props.mvpIsInteractiveDisabled ? 'none' : undefined,
       }}
       onClick={(e) => {
         props.openPopover?.(e)

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/selections.ts
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/selections.ts
@@ -38,6 +38,10 @@ export type KeyframeConnectionWithAddress = {
  * Returns an array of all the selected keyframes
  * that are connected to one another. Useful for changing
  * the tweening in between keyframes.
+ *
+ * TODO - rename to selectedKeyframeConnectionsD(), or better yet,
+ * make it a `prism.ensurePrism()` function, rather than returning
+ * a prism.
  */
 export function selectedKeyframeConnections(
   projectId: ProjectId,

--- a/theatre/studio/src/store/stateEditors.ts
+++ b/theatre/studio/src/store/stateEditors.ts
@@ -777,8 +777,6 @@ namespace stateEditors {
           /**
            * Sets the easing between keyframes
            *
-           *
-           *
            * X = in keyframeIds
            * * = not in keyframeIds
            * + = modified handle
@@ -786,6 +784,8 @@ namespace stateEditors {
            * X- --- -*- --- -X
            * X+ --- +*- --- -X+
            * ```
+           *
+           * TODO - explain further
            */
           export function setTweenBetweenKeyframes(
             p: WithoutSheetInstance<SheetObjectAddress> & {
@@ -850,6 +850,9 @@ namespace stateEditors {
             if (!track) return
             track.keyframes = track.keyframes.map((kf) => {
               if (kf.id === p.keyframeId) {
+                // Use given value or fallback to original value,
+                // allowing the caller to customize exactly which side
+                // of the curve they are editing.
                 return {
                   ...kf,
                   handles: [

--- a/theatre/studio/src/store/stateEditors.ts
+++ b/theatre/studio/src/store/stateEditors.ts
@@ -775,7 +775,17 @@ namespace stateEditors {
           }
 
           /**
-           * Sets the easing between two keyframes
+           * Sets the easing between keyframes
+           *
+           *
+           *
+           * X = in keyframeIds
+           * * = not in keyframeIds
+           * + = modified handle
+           * ```
+           * X- --- -*- --- -X
+           * X+ --- +*- --- -X+
+           * ```
            */
           export function setTweenBetweenKeyframes(
             p: WithoutSheetInstance<SheetObjectAddress> & {
@@ -825,6 +835,31 @@ namespace stateEditors {
               } else {
                 return kf
               }
+            })
+          }
+
+          export function setHandlesForKeyframe(
+            p: WithoutSheetInstance<SheetObjectAddress> & {
+              trackId: SequenceTrackId
+              keyframeId: KeyframeId
+              start?: [number, number]
+              end?: [number, number]
+            },
+          ) {
+            const track = _getTrack(p)
+            if (!track) return
+            track.keyframes = track.keyframes.map((kf) => {
+              if (kf.id === p.keyframeId) {
+                return {
+                  ...kf,
+                  handles: [
+                    p.end?.[0] ?? kf.handles[0],
+                    p.end?.[1] ?? kf.handles[1],
+                    p.start?.[0] ?? kf.handles[2],
+                    p.start?.[1] ?? kf.handles[3],
+                  ],
+                }
+              } else return kf
             })
           }
 

--- a/theatre/studio/src/uiComponents/Popover/usePopover.tsx
+++ b/theatre/studio/src/uiComponents/Popover/usePopover.tsx
@@ -46,7 +46,7 @@ type Opts = {
 }
 
 export default function usePopover(
-  _opts: Opts | (() => Opts),
+  opts: Opts | (() => Opts),
   render: () => React.ReactElement,
 ): [node: React.ReactNode, open: OpenFn, close: CloseFn, isOpen: boolean] {
   const _debug = (...args: any) => {}
@@ -55,7 +55,7 @@ export default function usePopover(
     isOpen: false,
   })
 
-  const optsRef = useRef(_opts)
+  const optsRef = useRef(opts)
 
   const close = useCallback<CloseFn>((reason: string): void => {
     _debug(`closing due to "${reason}"`)


### PR DESCRIPTION
- added background curves to multiple value curve editor

https://user-images.githubusercontent.com/11082236/170716407-b0ec2a4c-2a0b-45fd-841c-c98108a4c2a9.mp4

![image](https://user-images.githubusercontent.com/11082236/170572388-325cf727-3b6e-4962-acfc-ba98c35382b4.png)

## notes

- behaviour: selected connections are always edited when you click on a aggregate connection if they share a track with the aggregate. This may be unexpected because the selection can be in a different part of the timeline than the aggregate. This behaviour occurs because the aggregate connector and basic connector share the same selection logic, but the aggregate connector is passed, as a prop, more of the selection than the basic connector.

Co-authored-by: Cole Lawrence <cole@colelawrence.com>