### PR TITLE
Perfectly precise selections

### DIFF
--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/DopeSheetSelectionView.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/DopeSheetSelectionView.tsx
@@ -25,6 +25,8 @@ import {collectAggregateKeyframesInPrism} from './collectAggregateKeyframes'
 import type {ILogger, IUtilLogger} from '@theatre/shared/logger'
 import {useLogger} from '@theatre/studio/uiComponents/useLogger'
 
+const HITBOX_SIZE_PX = 5
+
 const Container = styled.div<{isShiftDown: boolean}>`
   cursor: ${(props) => (props.isShiftDown ? 'cell' : 'default')};
 `
@@ -149,13 +151,21 @@ namespace utils {
     const sheetObject = leaf.sheetObject
     const aggregatedKeyframes = collectAggregateKeyframesInPrism(logger, leaf)
 
-    const bottom = leaf.top + leaf.nodeHeight
-    if (bottom > bounds.v[0]) {
+    if (
+      leaf.top + leaf.nodeHeight / 2 + HITBOX_SIZE_PX > bounds.v[0] &&
+      leaf.top + leaf.nodeHeight / 2 - HITBOX_SIZE_PX < bounds.v[1]
+    ) {
       for (const [position, keyframes] of aggregatedKeyframes.byPosition) {
-        if (position <= bounds.h[0]) continue
-        if (position >= bounds.h[1]) break
-
-        // yes selected
+        if (
+          position + layout.scaledSpace.toUnitSpace(HITBOX_SIZE_PX) <=
+          bounds.h[0]
+        )
+          continue
+        if (
+          position - layout.scaledSpace.toUnitSpace(HITBOX_SIZE_PX) >=
+          bounds.h[1]
+        )
+          break
 
         for (const keyframeWithTrack of keyframes) {
           mutableSetDeep(
@@ -211,9 +221,26 @@ namespace utils {
         ].trackData[trackId],
       )!
 
+      if (
+        bounds.v[0] >
+          leaf.top + leaf.heightIncludingChildren / 2 + HITBOX_SIZE_PX ||
+        leaf.top + leaf.heightIncludingChildren / 2 - HITBOX_SIZE_PX >
+          bounds.v[1]
+      ) {
+        return
+      }
+
       for (const kf of trackData.keyframes) {
-        if (kf.position <= bounds.h[0]) continue
-        if (kf.position >= bounds.h[1]) break
+        if (
+          kf.position + layout.scaledSpace.toUnitSpace(HITBOX_SIZE_PX) <=
+          bounds.h[0]
+        )
+          continue
+        if (
+          kf.position - layout.scaledSpace.toUnitSpace(HITBOX_SIZE_PX) >=
+          bounds.h[1]
+        )
+          break
 
         mutableSetDeep(
           selectionByObjectKey,

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/DopeSheetSelectionView.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/DopeSheetSelectionView.tsx
@@ -408,7 +408,7 @@ const SelectionRectangleDiv = styled.div`
   position: absolute;
   background: rgba(255, 255, 255, 0.1);
   border: 1px dashed rgba(255, 255, 255, 0.4);
-  box-size: border-box;
+  box-sizing: border-box;
 `
 
 const sortBounds = (b: SelectionBounds): SelectionBounds => {

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/DopeSheetSelectionView.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/DopeSheetSelectionView.tsx
@@ -290,8 +290,6 @@ namespace utils {
       selectionByObjectKey,
     )
 
-    console.log(selectionByObjectKey)
-
     const sheet = layout.tree.sheet
     return {
       type: 'DopeSheetSelection',

--- a/theatre/studio/src/panels/SequenceEditorPanel/layout/layout.ts
+++ b/theatre/studio/src/panels/SequenceEditorPanel/layout/layout.ts
@@ -141,6 +141,9 @@ export type SequenceEditorPanelLayout = {
   }
   unitSpace: {}
   scaledSpace: {
+    /**
+     * TODO - scaledSpace with and without leftPadding are two different spaces. See if we can divide them so
+     */
     leftPadding: number
     fromUnitSpace(u: number): number
     toUnitSpace(s: number): number


### PR DESCRIPTION
- [x] Fix selection box misalignment
- [x] Improve keyframe selection hit-zone dimensions
- [ ] Document code

### Fix selection box misalignment
This fix involves correctly converting being normal space and left-padded space (normal space + left padding). The distinction between padded and normal on the space-level is important so that we don't have to go and ad-hoc patch every single calculation with the padding amount. Removing the padding in the drag handler and adding it back in the selection box might seem round-about, but this way we can perform every other calculation without conversions.

### Improve keyframe selection hit-zone dimensions
Currently, the hit-zones of the keyframes are represented by a vertical line spanning the entire track. This means, that you have to be needlessly precise and make sure you position the selection box only in the tracks in which you want to select keyframes on the vertical axis, while on the horizontal axis, the hit-zone is point-like, requiring the center of a keyfame to be covered by the selection in order to be included. The implementation in this PR aligns the hit-zone more closely with the visual appearance of the keyframe, both making selections more intuitive and requiring less precision from the user.