### PR TITLE
Fix incorrect selection.delete on connector

### DIFF
--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/KeyframeEditor/BasicKeyframeConnector.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/KeyframeEditor/BasicKeyframeConnector.tsx
@@ -258,10 +258,10 @@ function useConnectorContextMenu(
         {
           label: props.selection ? 'Delete (selection)' : 'Delete',
           callback: () => {
-            getStudio().transaction(({stateEditors}) => {
-              if (props.selection) {
-                props.selection.delete()
-              } else {
+            if (props.selection) {
+              props.selection.delete()
+            } else {
+              getStudio().transaction(({stateEditors}) => {
                 stateEditors.coreByProject.historic.sheetsById.sequence.deleteKeyframes(
                   {
                     ...props.leaf.sheetObject.address,
@@ -269,8 +269,8 @@ function useConnectorContextMenu(
                     trackId: props.leaf.trackId,
                   },
                 )
-              }
-            })
+              })
+            }
           },
         },
       ]


### PR DESCRIPTION
Co-authored-by: Andrew Prifer <AndrewPrifer@users.noreply.github.com>

Fixes this issue when deleting keyframes: 
![image](https://user-images.githubusercontent.com/11082236/172374778-024c7a41-527e-49bd-9846-e815c30e7c8a.png)
