### PR TITLE
Perfect snapping behavior for all snap targets

### DIFF
--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/AggregatedKeyframeTrack/AggregateKeyframeEditor/AggregateKeyframeDot.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/AggregatedKeyframeTrack/AggregateKeyframeEditor/AggregateKeyframeDot.tsx
@@ -21,7 +21,7 @@ import {
 import type {KeyframeWithPathToPropFromCommonRoot} from '@theatre/studio/store/types/ahistoric'
 import {commonRootOfPathsToProps} from '@theatre/shared/utils/addresses'
 import type {ILogger} from '@theatre/shared/logger'
-import {snapPositionsB} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/SnapTarget'
+import {snapPositionsB} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/KeyframeSnapTarget'
 
 type IAggregateKeyframeDotProps = {
   editorProps: IAggregateKeyframeEditorProps

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/AggregatedKeyframeTrack/AggregateKeyframeEditor/AggregateKeyframeDot.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/AggregatedKeyframeTrack/AggregateKeyframeEditor/AggregateKeyframeDot.tsx
@@ -23,7 +23,8 @@ import {commonRootOfPathsToProps} from '@theatre/shared/utils/addresses'
 import type {ILogger} from '@theatre/shared/logger'
 import {
   collectKeyframeSnapPositions,
-  snapPositionsB,
+  snapToNone,
+  snapToSome,
 } from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/KeyframeSnapTarget'
 import type {Keyframe} from '@theatre/core/projects/store/types/SheetState_Historic'
 
@@ -198,7 +199,7 @@ function useDragForAggregateKeyframeDot(
           },
         )
 
-        snapPositionsB.set(snapPositions)
+        snapToSome(snapPositions)
 
         if (
           props.selection &&
@@ -221,7 +222,7 @@ function useDragForAggregateKeyframeDot(
               onClick: options.onClickFromDrag,
               onDragEnd: (...args) => {
                 handlers.onDragEnd?.(...args)
-                snapPositionsB.set({})
+                snapToNone()
               },
             }
           )
@@ -272,7 +273,7 @@ function useDragForAggregateKeyframeDot(
               tempTransaction?.discard()
             }
 
-            snapPositionsB.set({})
+            snapToNone()
           },
           onClick(ev) {
             options.onClickFromDrag(ev)

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/AggregatedKeyframeTrack/AggregateKeyframeEditor/AggregateKeyframeVisualDot.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/AggregatedKeyframeTrack/AggregateKeyframeEditor/AggregateKeyframeVisualDot.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import {AggregateKeyframePositionIsSelected} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/AggregatedKeyframeTrack/AggregatedKeyframeTrack'
 import styled from 'styled-components'
 import {absoluteDims} from '@theatre/studio/utils/absoluteDims'
-import {DopeSnapHitZoneUI} from '@theatre/studio/panels/SequenceEditorPanel/RightOverlay/DopeSnapHitZoneUI'
+import {pointerEventsAutoInNormalMode} from '@theatre/studio/css'
 
 const DOT_SIZE_PX = 16
 const DOT_HOVER_SIZE_PX = DOT_SIZE_PX + 5
@@ -20,16 +20,15 @@ export const HitZone = styled.div`
   z-index: 2;
   cursor: ew-resize;
 
-  ${DopeSnapHitZoneUI.CSS}
+  position: absolute;
+  ${absoluteDims(12)};
+  ${pointerEventsAutoInNormalMode};
 
-  #pointer-root.draggingPositionInSequenceEditor & {
-    ${DopeSnapHitZoneUI.CSS_WHEN_SOMETHING_DRAGGING}
-  }
-
-  &:hover + ${DotContainer},
-  #pointer-root.draggingPositionInSequenceEditor &:hover + ${DotContainer},
-  // notice "," css "or"
-  &.${DopeSnapHitZoneUI.BEING_DRAGGED_CLASS} + ${DotContainer} {
+  &:hover
+    + ${DotContainer},
+    #pointer-root.draggingPositionInSequenceEditor
+    &:hover
+    + ${DotContainer} {
     ${absoluteDims(DOT_HOVER_SIZE_PX)}
   }
 `

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/AggregatedKeyframeTrack/AggregatedKeyframeTrack.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/AggregatedKeyframeTrack/AggregatedKeyframeTrack.tsx
@@ -32,7 +32,7 @@ import type Sequence from '@theatre/core/sequences/Sequence'
 import type {KeyframeWithPathToPropFromCommonRoot} from '@theatre/studio/store/types'
 import {collectAggregateSnapPositions} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/collectAggregateKeyframes'
 import SnapTarget, {
-  snapPositionsD,
+  snapPositionsB,
 } from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/SnapTarget'
 import {snapToAllKeyframesB} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/SnapTarget'
 
@@ -92,7 +92,7 @@ function AggregatedKeyframeTrack_memo(props: IAggregatedKeyframeTracksProps) {
       }),
     )
 
-  const snapPositions = useVal(snapPositionsD)
+  const snapPositions = useVal(snapPositionsB.derivation)
   const snapToAllKeyframes = useVal(snapToAllKeyframesB.derivation)
 
   const aggregateSnapPositions = useMemo(

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/AggregatedKeyframeTrack/AggregatedKeyframeTrack.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/AggregatedKeyframeTrack/AggregatedKeyframeTrack.tsx
@@ -31,10 +31,10 @@ import type {SequenceTrackId} from '@theatre/shared/utils/ids'
 import type Sequence from '@theatre/core/sequences/Sequence'
 import type {KeyframeWithPathToPropFromCommonRoot} from '@theatre/studio/store/types'
 import {collectAggregateSnapPositions} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/collectAggregateKeyframes'
-import SnapTarget, {
+import KeyframeSnapTarget, {
   snapPositionsB,
-} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/SnapTarget'
-import {snapToAllKeyframesB} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/SnapTarget'
+} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/KeyframeSnapTarget'
+import {snapToAllKeyframesB} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/KeyframeSnapTarget'
 
 const AggregatedKeyframeTrackContainer = styled.div`
   position: relative;
@@ -101,7 +101,7 @@ function AggregatedKeyframeTrack_memo(props: IAggregatedKeyframeTracksProps) {
   )
 
   const snapTargets = aggregateSnapPositions.map((position) => (
-    <SnapTarget
+    <KeyframeSnapTarget
       key={'snap-target-' + position}
       layoutP={layoutP}
       leaf={viewModel}
@@ -112,7 +112,11 @@ function AggregatedKeyframeTrack_memo(props: IAggregatedKeyframeTracksProps) {
   const keyframeEditors = posKfs.map(({position, keyframes}, index) => (
     <Fragment key={'agg-' + keyframes[0].kf.id}>
       {snapToAllKeyframes && (
-        <SnapTarget layoutP={layoutP} leaf={viewModel} position={position} />
+        <KeyframeSnapTarget
+          layoutP={layoutP}
+          leaf={viewModel}
+          position={position}
+        />
       )}
       <AggregateKeyframeEditor
         index={index}

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/AggregatedKeyframeTrack/AggregatedKeyframeTrack.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/AggregatedKeyframeTrack/AggregatedKeyframeTrack.tsx
@@ -32,9 +32,9 @@ import type Sequence from '@theatre/core/sequences/Sequence'
 import type {KeyframeWithPathToPropFromCommonRoot} from '@theatre/studio/store/types'
 import {collectAggregateSnapPositions} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/collectAggregateKeyframes'
 import KeyframeSnapTarget, {
-  snapPositionsB,
+  snapPositionsStateD,
 } from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/KeyframeSnapTarget'
-import {snapToAllKeyframesB} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/KeyframeSnapTarget'
+import {emptyObject} from '@theatre/shared/utils'
 
 const AggregatedKeyframeTrackContainer = styled.div`
   position: relative;
@@ -92,8 +92,14 @@ function AggregatedKeyframeTrack_memo(props: IAggregatedKeyframeTracksProps) {
       }),
     )
 
-  const snapPositions = useVal(snapPositionsB.derivation)
-  const snapToAllKeyframes = useVal(snapToAllKeyframesB.derivation)
+  const snapPositionsState = useVal(snapPositionsStateD)
+
+  const snapToAllKeyframes = snapPositionsState.mode === 'snapToAll'
+
+  const snapPositions =
+    snapPositionsState.mode === 'snapToSome'
+      ? snapPositionsState.positions
+      : emptyObject
 
   const aggregateSnapPositions = useMemo(
     () => collectAggregateSnapPositions(viewModel, snapPositions),

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/AggregatedKeyframeTrack/AggregatedKeyframeTrack.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/AggregatedKeyframeTrack/AggregatedKeyframeTrack.tsx
@@ -7,11 +7,11 @@ import type {
   SequenceEditorTree_SheetObject,
 } from '@theatre/studio/panels/SequenceEditorPanel/layout/tree'
 import type {Keyframe} from '@theatre/core/projects/store/types/SheetState_Historic'
-import {usePrism} from '@theatre/react'
+import {usePrism, useVal} from '@theatre/react'
 import type {Pointer} from '@theatre/dataverse'
 import {valueDerivation} from '@theatre/dataverse'
 import {val} from '@theatre/dataverse'
-import React from 'react'
+import React, {useMemo} from 'react'
 import styled from 'styled-components'
 import type {IContextMenuItem} from '@theatre/studio/uiComponents/simpleContextMenu/useContextMenu'
 import useContextMenu from '@theatre/studio/uiComponents/simpleContextMenu/useContextMenu'
@@ -21,16 +21,17 @@ import AggregateKeyframeEditor from './AggregateKeyframeEditor/AggregateKeyframe
 import type {AggregatedKeyframes} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/collectAggregateKeyframes'
 import {useLogger} from '@theatre/studio/uiComponents/useLogger'
 import getStudio from '@theatre/studio/getStudio'
-import type {
-  SheetObjectAddress} from '@theatre/shared/utils/addresses';
+import type {SheetObjectAddress} from '@theatre/shared/utils/addresses'
 import {
   decodePathToProp,
   doesPathStartWith,
-  encodePathToProp
+  encodePathToProp,
 } from '@theatre/shared/utils/addresses'
 import type {SequenceTrackId} from '@theatre/shared/utils/ids'
 import type Sequence from '@theatre/core/sequences/Sequence'
 import type {KeyframeWithPathToPropFromCommonRoot} from '@theatre/studio/store/types'
+import {collectAggregateSnapPositions} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/collectAggregateKeyframes'
+import SnapTarget, {snapPositionsD} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/SnapTarget'
 
 const AggregatedKeyframeTrackContainer = styled.div`
   position: relative;
@@ -88,6 +89,22 @@ function AggregatedKeyframeTrack_memo(props: IAggregatedKeyframeTracksProps) {
       }),
     )
 
+  const snapPositions = useVal(snapPositionsD)
+
+  const aggregateSnapPositions = useMemo(
+    () => collectAggregateSnapPositions(viewModel, snapPositions),
+    [snapPositions],
+  )
+
+  const snapTargets = aggregateSnapPositions.map((position) => (
+    <SnapTarget
+      key={'snap-target-' + position}
+      layoutP={layoutP}
+      leaf={viewModel}
+      position={position}
+    />
+  ))
+
   const keyframeEditors = posKfs.map(({position, keyframes}, index) => (
     <AggregateKeyframeEditor
       index={index}
@@ -111,6 +128,7 @@ function AggregatedKeyframeTrack_memo(props: IAggregatedKeyframeTracksProps) {
       }}
     >
       {keyframeEditors}
+      {snapTargets}
       {contextMenu}
     </AggregatedKeyframeTrackContainer>
   )

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/AggregatedKeyframeTrack/AggregatedKeyframeTrack.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/AggregatedKeyframeTrack/AggregatedKeyframeTrack.tsx
@@ -11,7 +11,7 @@ import {usePrism, useVal} from '@theatre/react'
 import type {Pointer} from '@theatre/dataverse'
 import {valueDerivation} from '@theatre/dataverse'
 import {val} from '@theatre/dataverse'
-import React, {useMemo} from 'react'
+import React, {Fragment, useMemo} from 'react'
 import styled from 'styled-components'
 import type {IContextMenuItem} from '@theatre/studio/uiComponents/simpleContextMenu/useContextMenu'
 import useContextMenu from '@theatre/studio/uiComponents/simpleContextMenu/useContextMenu'
@@ -31,7 +31,10 @@ import type {SequenceTrackId} from '@theatre/shared/utils/ids'
 import type Sequence from '@theatre/core/sequences/Sequence'
 import type {KeyframeWithPathToPropFromCommonRoot} from '@theatre/studio/store/types'
 import {collectAggregateSnapPositions} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/collectAggregateKeyframes'
-import SnapTarget, {snapPositionsD} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/SnapTarget'
+import SnapTarget, {
+  snapPositionsD,
+} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/SnapTarget'
+import {snapToAllKeyframesB} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/SnapTarget'
 
 const AggregatedKeyframeTrackContainer = styled.div`
   position: relative;
@@ -90,6 +93,7 @@ function AggregatedKeyframeTrack_memo(props: IAggregatedKeyframeTracksProps) {
     )
 
   const snapPositions = useVal(snapPositionsD)
+  const snapToAllKeyframes = useVal(snapToAllKeyframesB.derivation)
 
   const aggregateSnapPositions = useMemo(
     () => collectAggregateSnapPositions(viewModel, snapPositions),
@@ -106,18 +110,20 @@ function AggregatedKeyframeTrack_memo(props: IAggregatedKeyframeTracksProps) {
   ))
 
   const keyframeEditors = posKfs.map(({position, keyframes}, index) => (
-    <AggregateKeyframeEditor
-      index={index}
-      layoutP={layoutP}
-      viewModel={viewModel}
-      aggregateKeyframes={posKfs}
-      // To ensure that while dragging, we don't lose reference to the
-      // aggregate we're trying to drag.
-      key={'agg-' + keyframes[0].kf.id}
-      selection={
-        selectedPositions.has(position) === true ? selection : undefined
-      }
-    />
+    <Fragment key={'agg-' + keyframes[0].kf.id}>
+      {snapToAllKeyframes && (
+        <SnapTarget layoutP={layoutP} leaf={viewModel} position={position} />
+      )}
+      <AggregateKeyframeEditor
+        index={index}
+        layoutP={layoutP}
+        viewModel={viewModel}
+        aggregateKeyframes={posKfs}
+        selection={
+          selectedPositions.has(position) === true ? selection : undefined
+        }
+      />
+    </Fragment>
   ))
 
   return (

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/BasicKeyframedTrack.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/BasicKeyframedTrack.tsx
@@ -15,10 +15,8 @@ import getStudio from '@theatre/studio/getStudio'
 import {arePathsEqual} from '@theatre/shared/utils/addresses'
 import type {KeyframeWithPathToPropFromCommonRoot} from '@theatre/studio/store/types'
 import KeyframeSnapTarget, {
-  snapPositionsB,
+  snapPositionsStateD,
 } from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/KeyframeSnapTarget'
-import {uniq} from 'lodash-es'
-import {snapToAllKeyframesB} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/KeyframeSnapTarget'
 
 const Container = styled.div`
   position: relative;
@@ -63,12 +61,16 @@ const BasicKeyframedTrack: React.VFC<BasicKeyframedTracksProps> = React.memo(
       props,
     )
 
-    const snapPositions = uniq(
-      useVal(snapPositionsB.derivation)[leaf.sheetObject.address.objectKey]?.[
-        leaf.trackId
-      ] ?? [],
-    )
-    const snapToAllKeyframes = useVal(snapToAllKeyframesB.derivation)
+    const snapPositionsState = useVal(snapPositionsStateD)
+
+    const snapPositions =
+      snapPositionsState.mode === 'snapToSome'
+        ? snapPositionsState.positions[leaf.sheetObject.address.objectKey]?.[
+            leaf.trackId
+          ]
+        : [] ?? []
+
+    const snapToAllKeyframes = snapPositionsState.mode === 'snapToAll'
 
     const keyframeEditors = trackData.keyframes.map((kf, index) => (
       <Fragment key={'keyframe-' + kf.id}>

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/BasicKeyframedTrack.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/BasicKeyframedTrack.tsx
@@ -15,7 +15,7 @@ import getStudio from '@theatre/studio/getStudio'
 import {arePathsEqual} from '@theatre/shared/utils/addresses'
 import type {KeyframeWithPathToPropFromCommonRoot} from '@theatre/studio/store/types'
 import SnapTarget, {
-  snapPositionsD,
+  snapPositionsB,
 } from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/SnapTarget'
 import {uniq} from 'lodash-es'
 import {snapToAllKeyframesB} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/SnapTarget'
@@ -64,7 +64,7 @@ const BasicKeyframedTrack: React.VFC<BasicKeyframedTracksProps> = React.memo(
     )
 
     const snapPositions = uniq(
-      useVal(snapPositionsD)[leaf.sheetObject.address.objectKey]?.[
+      useVal(snapPositionsB.derivation)[leaf.sheetObject.address.objectKey]?.[
         leaf.trackId
       ] ?? [],
     )

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/BasicKeyframedTrack.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/BasicKeyframedTrack.tsx
@@ -14,11 +14,11 @@ import useRefAndState from '@theatre/studio/utils/useRefAndState'
 import getStudio from '@theatre/studio/getStudio'
 import {arePathsEqual} from '@theatre/shared/utils/addresses'
 import type {KeyframeWithPathToPropFromCommonRoot} from '@theatre/studio/store/types'
-import SnapTarget, {
+import KeyframeSnapTarget, {
   snapPositionsB,
-} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/SnapTarget'
+} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/KeyframeSnapTarget'
 import {uniq} from 'lodash-es'
-import {snapToAllKeyframesB} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/SnapTarget'
+import {snapToAllKeyframesB} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/KeyframeSnapTarget'
 
 const Container = styled.div`
   position: relative;
@@ -73,7 +73,11 @@ const BasicKeyframedTrack: React.VFC<BasicKeyframedTracksProps> = React.memo(
     const keyframeEditors = trackData.keyframes.map((kf, index) => (
       <Fragment key={'keyframe-' + kf.id}>
         {snapToAllKeyframes && (
-          <SnapTarget layoutP={layoutP} leaf={leaf} position={kf.position} />
+          <KeyframeSnapTarget
+            layoutP={layoutP}
+            leaf={leaf}
+            position={kf.position}
+          />
         )}
         <SingleKeyframeEditor
           keyframe={kf}
@@ -89,7 +93,7 @@ const BasicKeyframedTrack: React.VFC<BasicKeyframedTracksProps> = React.memo(
     ))
 
     const snapTargets = snapPositions.map((position) => (
-      <SnapTarget
+      <KeyframeSnapTarget
         key={'snap-target-' + position}
         layoutP={layoutP}
         leaf={leaf}

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/BasicKeyframedTrack.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/BasicKeyframedTrack.tsx
@@ -2,7 +2,7 @@ import type {TrackData} from '@theatre/core/projects/store/types/SheetState_Hist
 import type {SequenceEditorPanelLayout} from '@theatre/studio/panels/SequenceEditorPanel/layout/layout'
 import type {SequenceEditorTree_PrimitiveProp} from '@theatre/studio/panels/SequenceEditorPanel/layout/tree'
 import type {Keyframe} from '@theatre/core/projects/store/types/SheetState_Historic'
-import {usePrism} from '@theatre/react'
+import {usePrism, useVal} from '@theatre/react'
 import type {Pointer} from '@theatre/dataverse'
 import {val} from '@theatre/dataverse'
 import React from 'react'
@@ -14,6 +14,8 @@ import useRefAndState from '@theatre/studio/utils/useRefAndState'
 import getStudio from '@theatre/studio/getStudio'
 import {arePathsEqual} from '@theatre/shared/utils/addresses'
 import type {KeyframeWithPathToPropFromCommonRoot} from '@theatre/studio/store/types'
+import SnapTarget, {snapPositionsD} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/SnapTarget'
+import {uniq} from 'lodash-es'
 
 const Container = styled.div`
   position: relative;
@@ -58,6 +60,12 @@ const BasicKeyframedTrack: React.VFC<BasicKeyframedTracksProps> = React.memo(
       props,
     )
 
+    const snapPositions = uniq(
+      useVal(snapPositionsD)[leaf.sheetObject.address.objectKey]?.[
+        leaf.trackId
+      ] ?? [],
+    )
+
     const keyframeEditors = trackData.keyframes.map((kf, index) => (
       <SingleKeyframeEditor
         keyframe={kf}
@@ -70,6 +78,15 @@ const BasicKeyframedTrack: React.VFC<BasicKeyframedTracksProps> = React.memo(
       />
     ))
 
+    const snapTargets = snapPositions.map((position) => (
+      <SnapTarget
+        key={'snap-target-' + position}
+        layoutP={layoutP}
+        leaf={leaf}
+        position={position}
+      />
+    ))
+
     return (
       <Container
         ref={containerRef}
@@ -78,6 +95,7 @@ const BasicKeyframedTrack: React.VFC<BasicKeyframedTracksProps> = React.memo(
         }}
       >
         {keyframeEditors}
+        {snapTargets}
         {contextMenu}
       </Container>
     )

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/BasicKeyframedTrack.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/BasicKeyframedTrack.tsx
@@ -5,7 +5,7 @@ import type {Keyframe} from '@theatre/core/projects/store/types/SheetState_Histo
 import {usePrism, useVal} from '@theatre/react'
 import type {Pointer} from '@theatre/dataverse'
 import {val} from '@theatre/dataverse'
-import React from 'react'
+import React, {Fragment} from 'react'
 import styled from 'styled-components'
 import SingleKeyframeEditor from './KeyframeEditor/SingleKeyframeEditor'
 import type {IContextMenuItem} from '@theatre/studio/uiComponents/simpleContextMenu/useContextMenu'
@@ -14,8 +14,11 @@ import useRefAndState from '@theatre/studio/utils/useRefAndState'
 import getStudio from '@theatre/studio/getStudio'
 import {arePathsEqual} from '@theatre/shared/utils/addresses'
 import type {KeyframeWithPathToPropFromCommonRoot} from '@theatre/studio/store/types'
-import SnapTarget, {snapPositionsD} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/SnapTarget'
+import SnapTarget, {
+  snapPositionsD,
+} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/SnapTarget'
 import {uniq} from 'lodash-es'
+import {snapToAllKeyframesB} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/SnapTarget'
 
 const Container = styled.div`
   position: relative;
@@ -65,17 +68,24 @@ const BasicKeyframedTrack: React.VFC<BasicKeyframedTracksProps> = React.memo(
         leaf.trackId
       ] ?? [],
     )
+    const snapToAllKeyframes = useVal(snapToAllKeyframesB.derivation)
 
     const keyframeEditors = trackData.keyframes.map((kf, index) => (
-      <SingleKeyframeEditor
-        keyframe={kf}
-        index={index}
-        trackData={trackData}
-        layoutP={layoutP}
-        leaf={leaf}
-        key={'keyframe-' + kf.id}
-        selection={selectedKeyframeIds[kf.id] === true ? selection : undefined}
-      />
+      <Fragment key={'keyframe-' + kf.id}>
+        {snapToAllKeyframes && (
+          <SnapTarget layoutP={layoutP} leaf={leaf} position={kf.position} />
+        )}
+        <SingleKeyframeEditor
+          keyframe={kf}
+          index={index}
+          trackData={trackData}
+          layoutP={layoutP}
+          leaf={leaf}
+          selection={
+            selectedKeyframeIds[kf.id] === true ? selection : undefined
+          }
+        />
+      </Fragment>
     ))
 
     const snapTargets = snapPositions.map((position) => (

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/KeyframeEditor/SingleKeyframeDot.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/KeyframeEditor/SingleKeyframeDot.tsx
@@ -23,7 +23,7 @@ import {useLogger} from '@theatre/studio/uiComponents/useLogger'
 import type {ILogger} from '@theatre/shared/logger'
 import {copyableKeyframesFromSelection} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/selections'
 import {pointerEventsAutoInNormalMode} from '@theatre/studio/css'
-import {snapPositionsB} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/SnapTarget'
+import {snapPositionsB} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/KeyframeSnapTarget'
 
 export const DOT_SIZE_PX = 6
 const DOT_HOVER_SIZE_PX = DOT_SIZE_PX + 5

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/KeyframeEditor/SingleKeyframeDot.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/KeyframeEditor/SingleKeyframeDot.tsx
@@ -25,7 +25,8 @@ import {copyableKeyframesFromSelection} from '@theatre/studio/panels/SequenceEdi
 import {pointerEventsAutoInNormalMode} from '@theatre/studio/css'
 import {
   collectKeyframeSnapPositions,
-  snapPositionsB,
+  snapToNone,
+  snapToSome,
 } from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/KeyframeSnapTarget'
 
 export const DOT_SIZE_PX = 6
@@ -231,7 +232,7 @@ function useDragForSingleKeyframeDot(
           },
         )
 
-        snapPositionsB.set(snapPositions)
+        snapToSome(snapPositions)
 
         if (props.selection) {
           const {selection, leaf} = props
@@ -255,7 +256,7 @@ function useDragForSingleKeyframeDot(
               onClick: options.onClickFromDrag,
               onDragEnd: (...args) => {
                 handlers.onDragEnd?.(...args)
-                snapPositionsB.set({})
+                snapToNone()
               },
             }
           )
@@ -305,7 +306,7 @@ function useDragForSingleKeyframeDot(
               tempTransaction?.discard()
             }
 
-            snapPositionsB.set({})
+            snapToNone()
           },
           onClick(ev) {
             options.onClickFromDrag(ev)

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/HorizontallyScrollableArea.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/HorizontallyScrollableArea.tsx
@@ -12,7 +12,7 @@ import {pointerEventsAutoInNormalMode} from '@theatre/studio/css'
 import {useCssCursorLock} from '@theatre/studio/uiComponents/PointerEventsHandler'
 import type {IRange} from '@theatre/shared/utils/types'
 import DopeSnap from '@theatre/studio/panels/SequenceEditorPanel/RightOverlay/DopeSnap'
-import {snapToAllKeyframesB} from './SnapTarget'
+import {snapToAllKeyframesB} from './KeyframeSnapTarget'
 
 const Container = styled.div`
   position: absolute;

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/HorizontallyScrollableArea.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/HorizontallyScrollableArea.tsx
@@ -12,6 +12,7 @@ import {pointerEventsAutoInNormalMode} from '@theatre/studio/css'
 import {useCssCursorLock} from '@theatre/studio/uiComponents/PointerEventsHandler'
 import type {IRange} from '@theatre/shared/utils/types'
 import DopeSnap from '@theatre/studio/panels/SequenceEditorPanel/RightOverlay/DopeSnap'
+import {snapToAllKeyframesB} from './SnapTarget'
 
 const Container = styled.div`
   position: absolute;
@@ -115,6 +116,8 @@ function useDragPlayheadHandlers(
         const scaledSpaceToUnitSpace = val(layoutP.scaledSpace.toUnitSpace)
         setIsSeeking(true)
 
+        snapToAllKeyframesB.set(true)
+
         return {
           onDrag(dx: number, _, event) {
             const deltaPos = scaledSpaceToUnitSpace(dx)
@@ -135,6 +138,7 @@ function useDragPlayheadHandlers(
           },
           onDragEnd() {
             setIsSeeking(false)
+            snapToAllKeyframesB.set(false)
           },
         }
       },

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/HorizontallyScrollableArea.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/HorizontallyScrollableArea.tsx
@@ -12,7 +12,7 @@ import {pointerEventsAutoInNormalMode} from '@theatre/studio/css'
 import {useCssCursorLock} from '@theatre/studio/uiComponents/PointerEventsHandler'
 import type {IRange} from '@theatre/shared/utils/types'
 import DopeSnap from '@theatre/studio/panels/SequenceEditorPanel/RightOverlay/DopeSnap'
-import {snapToAllKeyframesB} from './KeyframeSnapTarget'
+import {snapToAll, snapToNone} from './KeyframeSnapTarget'
 
 const Container = styled.div`
   position: absolute;
@@ -116,7 +116,7 @@ function useDragPlayheadHandlers(
         const scaledSpaceToUnitSpace = val(layoutP.scaledSpace.toUnitSpace)
         setIsSeeking(true)
 
-        snapToAllKeyframesB.set(true)
+        snapToAll()
 
         return {
           onDrag(dx: number, _, event) {
@@ -138,7 +138,7 @@ function useDragPlayheadHandlers(
           },
           onDragEnd() {
             setIsSeeking(false)
-            snapToAllKeyframesB.set(false)
+            snapToNone()
           },
         }
       },

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/KeyframeSnapTarget.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/KeyframeSnapTarget.tsx
@@ -62,14 +62,35 @@ export type KeyframeSnapPositions = {
   }
 }
 
-// The following boxes are read by BasicKeyframeTrack and AggregateKeyframeTrack
-// to place snap targets in the keyframe tracks.
+const stateB = new Box<
+  | {
+      // all keyframes must be snap targets
+      mode: 'snapToAll'
+    }
+  | {
+      // only these keyframes must be snap targets
+      mode: 'snapToSome'
+      positions: KeyframeSnapPositions
+    }
+  | {
+      // no keyframe should be a snap target
+      mode: 'snapToNone'
+    }
+>({mode: 'snapToNone'})
 
-// A box holding all the valid snap positions per track per object.
-export const snapPositionsB = new Box<KeyframeSnapPositions>({})
+export const snapPositionsStateD = stateB.derivation
 
-// A convenience flag to specify that we want to snap everywhere where there's currently a keyframe.
-export const snapToAllKeyframesB = new Box(false)
+export function snapToAll() {
+  stateB.set({mode: 'snapToAll'})
+}
+
+export function snapToNone() {
+  stateB.set({mode: 'snapToNone'})
+}
+
+export function snapToSome(positions: KeyframeSnapPositions) {
+  stateB.set({mode: 'snapToSome', positions})
+}
 
 export function collectKeyframeSnapPositions(
   tracksByObject: HistoricPositionalSequence['tracksByObject'],

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/KeyframeSnapTarget.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/KeyframeSnapTarget.tsx
@@ -4,6 +4,7 @@ import {Box, val} from '@theatre/dataverse'
 import React from 'react'
 import styled from 'styled-components'
 import {DopeSnapHitZoneUI} from '@theatre/studio/panels/SequenceEditorPanel/RightOverlay/DopeSnapHitZoneUI'
+import type {ObjectAddressKey, SequenceTrackId} from '@theatre/shared/utils/ids'
 
 const HitZone = styled.div`
   z-index: 1;
@@ -26,7 +27,7 @@ export type ISnapTargetPRops = {
   position: number
 }
 
-const SnapTarget: React.VFC<ISnapTargetPRops> = (props) => {
+const KeyframeSnapTarget: React.VFC<ISnapTargetPRops> = (props) => {
   return (
     <Container
       style={{
@@ -48,14 +49,14 @@ const SnapTarget: React.VFC<ISnapTargetPRops> = (props) => {
   )
 }
 
-export default SnapTarget
+export default KeyframeSnapTarget
 
 // The following boxes are read by BasicKeyframeTrack and AggregateKeyframeTrack
 // to place snap targets in the keyframe tracks.
 
 // A box holding all the valid snap positions per track per object.
 export const snapPositionsB = new Box<{
-  [key: string]: {[key: string]: number[]}
+  [objectKey: ObjectAddressKey]: {[trackId: SequenceTrackId]: number[]}
 }>({})
 
 // A convenience flag to specify that we want to snap everywhere where there's currently a keyframe.

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/KeyframeSnapTarget.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/KeyframeSnapTarget.tsx
@@ -5,6 +5,11 @@ import React from 'react'
 import styled from 'styled-components'
 import {DopeSnapHitZoneUI} from '@theatre/studio/panels/SequenceEditorPanel/RightOverlay/DopeSnapHitZoneUI'
 import type {ObjectAddressKey, SequenceTrackId} from '@theatre/shared/utils/ids'
+import type {
+  BasicKeyframedTrack,
+  HistoricPositionalSequence,
+  Keyframe,
+} from '@theatre/core/projects/store/types/SheetState_Historic'
 
 const HitZone = styled.div`
   z-index: 1;
@@ -51,13 +56,53 @@ const KeyframeSnapTarget: React.VFC<ISnapTargetPRops> = (props) => {
 
 export default KeyframeSnapTarget
 
+export type KeyframeSnapPositions = {
+  [objectKey: ObjectAddressKey]: {
+    [trackId: SequenceTrackId]: number[]
+  }
+}
+
 // The following boxes are read by BasicKeyframeTrack and AggregateKeyframeTrack
 // to place snap targets in the keyframe tracks.
 
 // A box holding all the valid snap positions per track per object.
-export const snapPositionsB = new Box<{
-  [objectKey: ObjectAddressKey]: {[trackId: SequenceTrackId]: number[]}
-}>({})
+export const snapPositionsB = new Box<KeyframeSnapPositions>({})
 
 // A convenience flag to specify that we want to snap everywhere where there's currently a keyframe.
 export const snapToAllKeyframesB = new Box(false)
+
+export function collectKeyframeSnapPositions(
+  tracksByObject: HistoricPositionalSequence['tracksByObject'],
+  shouldIncludeKeyframe: (
+    kf: Keyframe,
+    track: {
+      trackId: SequenceTrackId
+      trackData: BasicKeyframedTrack
+      objectKey: ObjectAddressKey
+    },
+  ) => boolean,
+): KeyframeSnapPositions {
+  return Object.fromEntries(
+    Object.entries(tracksByObject).map(
+      ([objectKey, trackDataAndTrackIdByPropPath]) => [
+        objectKey,
+        Object.fromEntries(
+          Object.entries(trackDataAndTrackIdByPropPath!.trackData).map(
+            ([trackId, track]) => [
+              trackId,
+              track!.keyframes
+                .filter((kf) =>
+                  shouldIncludeKeyframe(kf, {
+                    trackId,
+                    trackData: track!,
+                    objectKey,
+                  }),
+                )
+                .map((keyframe) => keyframe.position),
+            ],
+          ),
+        ),
+      ],
+    ),
+  )
+}

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/SnapTarget.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/SnapTarget.tsx
@@ -50,9 +50,14 @@ const SnapTarget: React.VFC<ISnapTargetPRops> = (props) => {
 
 export default SnapTarget
 
+// The following boxes are read by BasicKeyframeTrack and AggregateKeyframeTrack
+// to place snap targets in the keyframe tracks.
+
+// A box holding all the valid snap positions per track per object.
 export const snapPositionsB = new Box<{
   [key: string]: {[key: string]: number[]}
 }>({})
 export const snapPositionsD = snapPositionsB.derivation
 
+// A convenience flag to specify that we want to snap everywhere where there's currently a keyframe.
 export const snapToAllKeyframesB = new Box(false)

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/SnapTarget.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/SnapTarget.tsx
@@ -57,7 +57,6 @@ export default SnapTarget
 export const snapPositionsB = new Box<{
   [key: string]: {[key: string]: number[]}
 }>({})
-export const snapPositionsD = snapPositionsB.derivation
 
 // A convenience flag to specify that we want to snap everywhere where there's currently a keyframe.
 export const snapToAllKeyframesB = new Box(false)

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/SnapTarget.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/SnapTarget.tsx
@@ -18,11 +18,6 @@ const HitZone = styled.div`
 
 const Container = styled.div`
   position: absolute;
-  &::after {
-    content: 'snap';
-    background: red;
-    pointer-events: none;
-  }
 `
 
 export type ISnapTargetPRops = {

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/SnapTarget.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/SnapTarget.tsx
@@ -1,0 +1,61 @@
+import type {SequenceEditorPanelLayout} from '@theatre/studio/panels/SequenceEditorPanel/layout/layout'
+import type {Pointer} from '@theatre/dataverse'
+import {Box, val} from '@theatre/dataverse'
+import React from 'react'
+import styled from 'styled-components'
+import {DopeSnapHitZoneUI} from '@theatre/studio/panels/SequenceEditorPanel/RightOverlay/DopeSnapHitZoneUI'
+
+const HitZone = styled.div`
+  z-index: 1;
+  cursor: ew-resize;
+
+  ${DopeSnapHitZoneUI.CSS}
+
+  #pointer-root.draggingPositionInSequenceEditor & {
+    ${DopeSnapHitZoneUI.CSS_WHEN_SOMETHING_DRAGGING}
+  }
+`
+
+const Container = styled.div`
+  position: absolute;
+  &::after {
+    content: 'snap';
+    background: red;
+    pointer-events: none;
+  }
+`
+
+export type ISnapTargetPRops = {
+  layoutP: Pointer<SequenceEditorPanelLayout>
+  leaf: {nodeHeight: number}
+  position: number
+}
+
+const SnapTarget: React.VFC<ISnapTargetPRops> = (props) => {
+  return (
+    <Container
+      style={{
+        top: `${props.leaf.nodeHeight / 2}px`,
+        left: `calc(${val(
+          props.layoutP.scaledSpace.leftPadding,
+        )}px + calc(var(--unitSpaceToScaledSpaceMultiplier) * ${
+          props.position
+        }px))`,
+      }}
+    >
+      <HitZone
+        {...DopeSnapHitZoneUI.reactProps({
+          isDragging: false,
+          position: props.position,
+        })}
+      />
+    </Container>
+  )
+}
+
+export default SnapTarget
+
+export const snapPositionsB = new Box<{
+  [key: string]: {[key: string]: number[]}
+}>({})
+export const snapPositionsD = snapPositionsB.derivation

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/SnapTarget.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/SnapTarget.tsx
@@ -54,3 +54,5 @@ export const snapPositionsB = new Box<{
   [key: string]: {[key: string]: number[]}
 }>({})
 export const snapPositionsD = snapPositionsB.derivation
+
+export const snapToAllKeyframesB = new Box(false)

--- a/theatre/studio/src/panels/SequenceEditorPanel/RightOverlay/MarkerDot.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/RightOverlay/MarkerDot.tsx
@@ -22,7 +22,10 @@ import {zIndexes} from '@theatre/studio/panels/SequenceEditorPanel/SequenceEdito
 import DopeSnap from './DopeSnap'
 import {absoluteDims} from '@theatre/studio/utils/absoluteDims'
 import {DopeSnapHitZoneUI} from './DopeSnapHitZoneUI'
-import {snapToAllKeyframesB} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/KeyframeSnapTarget'
+import {
+  snapToAll,
+  snapToNone,
+} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/KeyframeSnapTarget'
 
 const MARKER_SIZE_W_PX = 12
 const MARKER_SIZE_H_PX = 12
@@ -222,7 +225,7 @@ function useDragMarker(
         const toUnitSpace = val(props.layoutP.scaledSpace.toUnitSpace)
         let tempTransaction: CommitOrDiscard | undefined
 
-        snapToAllKeyframesB.set(true)
+        snapToAll()
 
         return {
           onDrag(dx, _dy, event) {
@@ -254,7 +257,7 @@ function useDragMarker(
             if (dragHappened) tempTransaction?.commit()
             else tempTransaction?.discard()
 
-            snapToAllKeyframesB.set(false)
+            snapToNone()
           },
         }
       },

--- a/theatre/studio/src/panels/SequenceEditorPanel/RightOverlay/MarkerDot.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/RightOverlay/MarkerDot.tsx
@@ -22,6 +22,7 @@ import {zIndexes} from '@theatre/studio/panels/SequenceEditorPanel/SequenceEdito
 import DopeSnap from './DopeSnap'
 import {absoluteDims} from '@theatre/studio/utils/absoluteDims'
 import {DopeSnapHitZoneUI} from './DopeSnapHitZoneUI'
+import {snapToAllKeyframesB} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/SnapTarget'
 
 const MARKER_SIZE_W_PX = 12
 const MARKER_SIZE_H_PX = 12
@@ -221,6 +222,8 @@ function useDragMarker(
         const toUnitSpace = val(props.layoutP.scaledSpace.toUnitSpace)
         let tempTransaction: CommitOrDiscard | undefined
 
+        snapToAllKeyframesB.set(true)
+
         return {
           onDrag(dx, _dy, event) {
             const original = markerAtStartOfDrag
@@ -250,6 +253,8 @@ function useDragMarker(
           onDragEnd(dragHappened) {
             if (dragHappened) tempTransaction?.commit()
             else tempTransaction?.discard()
+
+            snapToAllKeyframesB.set(false)
           },
         }
       },

--- a/theatre/studio/src/panels/SequenceEditorPanel/RightOverlay/MarkerDot.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/RightOverlay/MarkerDot.tsx
@@ -22,7 +22,7 @@ import {zIndexes} from '@theatre/studio/panels/SequenceEditorPanel/SequenceEdito
 import DopeSnap from './DopeSnap'
 import {absoluteDims} from '@theatre/studio/utils/absoluteDims'
 import {DopeSnapHitZoneUI} from './DopeSnapHitZoneUI'
-import {snapToAllKeyframesB} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/SnapTarget'
+import {snapToAllKeyframesB} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/KeyframeSnapTarget'
 
 const MARKER_SIZE_W_PX = 12
 const MARKER_SIZE_H_PX = 12

--- a/theatre/studio/src/panels/SequenceEditorPanel/RightOverlay/Playhead.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/RightOverlay/Playhead.tsx
@@ -27,7 +27,7 @@ import useContextMenu from '@theatre/studio/uiComponents/simpleContextMenu/useCo
 import getStudio from '@theatre/studio/getStudio'
 import {generateSequenceMarkerId} from '@theatre/shared/utils/ids'
 import DopeSnap from './DopeSnap'
-import {snapToAllKeyframesB} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/SnapTarget'
+import {snapToAllKeyframesB} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/KeyframeSnapTarget'
 
 const Container = styled.div<{isVisible: boolean}>`
   --thumbColor: #00e0ff;

--- a/theatre/studio/src/panels/SequenceEditorPanel/RightOverlay/Playhead.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/RightOverlay/Playhead.tsx
@@ -27,7 +27,10 @@ import useContextMenu from '@theatre/studio/uiComponents/simpleContextMenu/useCo
 import getStudio from '@theatre/studio/getStudio'
 import {generateSequenceMarkerId} from '@theatre/shared/utils/ids'
 import DopeSnap from './DopeSnap'
-import {snapToAllKeyframesB} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/KeyframeSnapTarget'
+import {
+  snapToAll,
+  snapToNone,
+} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/KeyframeSnapTarget'
 
 const Container = styled.div<{isVisible: boolean}>`
   --thumbColor: #00e0ff;
@@ -215,7 +218,7 @@ const Playhead: React.FC<{layoutP: Pointer<SequenceEditorPanelLayout>}> = ({
         const setIsSeeking = val(layoutP.seeker.setIsSeeking)
         setIsSeeking(true)
 
-        snapToAllKeyframesB.set(true)
+        snapToAll()
 
         return {
           onDrag(dx, _, event) {
@@ -230,7 +233,7 @@ const Playhead: React.FC<{layoutP: Pointer<SequenceEditorPanelLayout>}> = ({
           },
           onDragEnd(dragHappened) {
             setIsSeeking(false)
-            snapToAllKeyframesB.set(false)
+            snapToNone()
           },
           onClick(e) {
             openPopover(e, thumbRef.current!)

--- a/theatre/studio/src/panels/SequenceEditorPanel/RightOverlay/Playhead.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/RightOverlay/Playhead.tsx
@@ -216,7 +216,6 @@ const Playhead: React.FC<{layoutP: Pointer<SequenceEditorPanelLayout>}> = ({
         setIsSeeking(true)
 
         snapToAllKeyframesB.set(true)
-        console.log('hello')
 
         return {
           onDrag(dx, _, event) {

--- a/theatre/studio/src/panels/SequenceEditorPanel/RightOverlay/Playhead.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/RightOverlay/Playhead.tsx
@@ -27,6 +27,7 @@ import useContextMenu from '@theatre/studio/uiComponents/simpleContextMenu/useCo
 import getStudio from '@theatre/studio/getStudio'
 import {generateSequenceMarkerId} from '@theatre/shared/utils/ids'
 import DopeSnap from './DopeSnap'
+import {snapToAllKeyframesB} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/SnapTarget'
 
 const Container = styled.div<{isVisible: boolean}>`
   --thumbColor: #00e0ff;
@@ -214,6 +215,9 @@ const Playhead: React.FC<{layoutP: Pointer<SequenceEditorPanelLayout>}> = ({
         const setIsSeeking = val(layoutP.seeker.setIsSeeking)
         setIsSeeking(true)
 
+        snapToAllKeyframesB.set(true)
+        console.log('hello')
+
         return {
           onDrag(dx, _, event) {
             const deltaPos = scaledSpaceToUnitSpace(dx)
@@ -227,6 +231,7 @@ const Playhead: React.FC<{layoutP: Pointer<SequenceEditorPanelLayout>}> = ({
           },
           onDragEnd(dragHappened) {
             setIsSeeking(false)
+            snapToAllKeyframesB.set(false)
           },
           onClick(e) {
             openPopover(e, thumbRef.current!)


### PR DESCRIPTION
The current snap implementation regards every keyframe or aggregate keyframe as snap target during draggings. This leads to issues, since we don't want to snap to keyframes that are currently being dragged, such as the dragged keyframe, any selection it may be a part of, its agregate keyframes, or its child keyframes in case of an aggregate.

This PR fixes this by precalculating all the valid snap positions per track at the start of the drag.

Unlike the previous snapping solution, this one separates the identity of snap positions from those of keyframes/agregate keyframes. This is necessary since keyframes can diappear mid-drag, like when the dragged keyframe overlaps another, which leads to flicker as the other keyframe disappears on snap, and reappears as its snap target is no longer in effect, then disappears again, etc.

