### PR TITLE
Fix `process.env.version` in browser-bundles

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -73,6 +73,7 @@ module.exports = {
       rules: {
         'react/jsx-uses-react': 'error',
         'react/jsx-uses-vars': 'error',
+        'tsdoc/syntax': 'off',
       },
       parser: 'espree',
       parserOptions: {

--- a/compatibility-tests/scripts/utils.mjs
+++ b/compatibility-tests/scripts/utils.mjs
@@ -109,7 +109,7 @@ const packagesToPublish = [
  * @param {string} hash - Hash of the latest commit (or any other string)
  * @returns {Promise<() => void>} - An async function that restores the package.json files to their original version
  */
-async function assignVersions(workspacesListObjects, hash) {
+async function writeVersionsToPackageJSONs(workspacesListObjects, hash) {
   /**
    * An array of functions each of which restores a certain package.json to its original state
    * @type {Array<() => void>}
@@ -181,7 +181,10 @@ async function releaseToVerdaccio() {
     .filter(Boolean)
     .map((x) => JSON.parse(x))
 
-  const restorePackages = await assignVersions(workspacesListObjects, version)
+  const restorePackages = await writeVersionsToPackageJSONs(
+    workspacesListObjects,
+    version,
+  )
 
   process.on('SIGINT', async function cleanup(a) {
     restorePackages()

--- a/packages/browser-bundles/devEnv/build.ts
+++ b/packages/browser-bundles/devEnv/build.ts
@@ -4,7 +4,9 @@ import type {Plugin} from 'esbuild'
 
 const definedGlobals = {
   global: 'window',
-  'process.env.version': JSON.stringify(require('../package.json').version),
+  'process.env.THEATRE_VERSION': JSON.stringify(
+    require('../package.json').version,
+  ),
 }
 
 function createBundles(watch: boolean) {

--- a/packages/browser-bundles/devEnv/build.ts
+++ b/packages/browser-bundles/devEnv/build.ts
@@ -4,6 +4,7 @@ import type {Plugin} from 'esbuild'
 
 const definedGlobals = {
   global: 'window',
+  'process.env.version': JSON.stringify(require('../package.json').version),
 }
 
 function createBundles(watch: boolean) {

--- a/packages/r3f/devEnv/bundle.ts
+++ b/packages/r3f/devEnv/bundle.ts
@@ -2,7 +2,9 @@ import path = require('path')
 import {build} from 'esbuild'
 
 const definedGlobals = {
-  'process.env.version': JSON.stringify(require('../package.json').version),
+  'process.env.THEATRE_VERSION': JSON.stringify(
+    require('../package.json').version,
+  ),
   'process.env.NODE_ENV': JSON.stringify('production'),
 }
 

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -134,7 +134,7 @@ const packagesWhoseVersionsShouldBump = [
   const skipTypescriptEmit = argv['skip-ts'] === true
 
   console.log('Assigning versions')
-  await assignVersions(version)
+  await writeVersionsToPackageJSONs(version)
 
   console.log('Building all packages')
   await Promise.all(
@@ -163,7 +163,7 @@ const packagesWhoseVersionsShouldBump = [
 
   $.verbose = true
 
-  await assignVersions(version)
+  await writeVersionsToPackageJSONs(version)
 
   console.log('Committing/tagging')
 
@@ -188,7 +188,7 @@ const packagesWhoseVersionsShouldBump = [
 })()
 
 /** @param {string} monorepoVersion */
-async function assignVersions(monorepoVersion) {
+async function writeVersionsToPackageJSONs(monorepoVersion) {
   for (const packagePathRelativeFromRoot of packagesWhoseVersionsShouldBump) {
     const pathToPackage = path.resolve(
       __dirname,

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -5,12 +5,7 @@
     "checkJs": true,
     "noEmit": true,
     "resolveJsonModule": true,
-    "types": [
-      "zx"
-    ]
+    "types": ["zx", "node"]
   },
-  "include": [
-    "*.mjs",
-    "**/*.mjs",
-  ]
+  "include": ["*.mjs", "**/*.mjs"]
 }

--- a/theatre/core/src/CoreBundle.ts
+++ b/theatre/core/src/CoreBundle.ts
@@ -18,7 +18,7 @@ export default class CoreBundle {
   }
 
   get version() {
-    return process.env.version
+    return process.env.THEATRE_VERSION
   }
 
   getBitsForStudio(studio: Studio, callback: (bits: CoreBits) => void) {

--- a/theatre/core/src/index.ts
+++ b/theatre/core/src/index.ts
@@ -30,8 +30,10 @@ function registerCoreBundle() {
   if (typeof window == 'undefined') return
 
   // another core bundle may already be registered
-  // @ts-ignore ignore
-  const existingBundle = window[globalVariableNames.coreBundle]
+
+  const existingBundle: CoreBundle | undefined =
+    // @ts-ignore ignore
+    window[globalVariableNames.coreBundle]
 
   if (typeof existingBundle !== 'undefined') {
     if (

--- a/theatre/devEnv/buildUtils.ts
+++ b/theatre/devEnv/buildUtils.ts
@@ -2,7 +2,7 @@ import path from 'path'
 import {build} from 'esbuild'
 
 export const definedGlobals = {
-  'process.env.version': JSON.stringify(
+  'process.env.THEATRE_VERSION': JSON.stringify(
     require('../studio/package.json').version,
   ),
   // json-touch-patch (an unmaintained package) reads this value. We patch it to just 'Set', becauce

--- a/theatre/globals.d.ts
+++ b/theatre/globals.d.ts
@@ -11,7 +11,7 @@ interface NodeModule {
 
 interface ProcessEnv {
   NODE_ENV: 'development' | 'production' | 'test'
-  version: string
+  THEATRE_VERSION: string
 }
 
 declare module '*.svg' {

--- a/theatre/studio/src/checkForUpdates.ts
+++ b/theatre/studio/src/checkForUpdates.ts
@@ -26,7 +26,7 @@ export default async function checkForUpdates() {
     try {
       const response = await fetch(
         new Request(
-          `https://updates.theatrejs.com/updates/${process.env.version}`,
+          `https://updates.theatrejs.com/updates/${process.env.THEATRE_VERSION}`,
         ),
       )
       if (response.ok) {

--- a/theatre/studio/src/toolbars/MoreMenu/MoreMenu.tsx
+++ b/theatre/studio/src/toolbars/MoreMenu/MoreMenu.tsx
@@ -104,7 +104,7 @@ const UpdateDot = styled.div`
   border-radius: 50%;
 `
 
-const version: string = process.env.version ?? '0.4.0'
+const version: string = process.env.THEATRE_VERSION ?? '0.4.0'
 
 const untaggedVersion: string = version.match(/^[^\-]+/)![0]
 


### PR DESCRIPTION
- also fix tsdoc warns in mjs files

Co-authored-by: Fülöp Kovács <kovacs.fulop@gmail.com>
Co-authored-by: Cole Lawrence <cole@colelawrence.com>