### PR TITLE
Rename the `Test` job from `compability-tests` to avoid name collision with another job in the `main` workflow

### DIFF
--- a/.github/workflows/compatibility-tests.yml
+++ b/.github/workflows/compatibility-tests.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  Test:
+  Compatibility-Tests:
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
We want to make sure that no PR gets merged into `main` if certain jobs do not pass. Currently we use the `Test` name for two different jobs in two different workflows (`compatibility-tests` and `main`), which confuses GitHub and makes it impossible for us to add an enforcement rule for both (or even being sure which one of them we enforce). I fixed this problem by renaming one of them.
