### PR TITLE
Fix react fragments not having a `key`.

### DIFF
--- a/theatre/studio/src/toolbars/ExtensionToolbar/ExtensionToolbar.tsx
+++ b/theatre/studio/src/toolbars/ExtensionToolbar/ExtensionToolbar.tsx
@@ -73,14 +73,10 @@ export const ExtensionToolbar: React.FC<{toolbarId: string}> = ({
     if (!extension || !extension.toolbars?.[toolbarId]) continue
 
     groups.push(
-      <>
+      <React.Fragment key={'extensionToolbar-' + extension.id}>
         {isAfterFirstGroup ? <GroupDivider></GroupDivider> : undefined}
-        <ExtensionToolsetRender
-          extension={extension}
-          key={'extensionToolbar-' + extension.id}
-          toolbarId={toolbarId}
-        />
-      </>,
+        <ExtensionToolsetRender extension={extension} toolbarId={toolbarId} />
+      </React.Fragment>,
     )
 
     isAfterFirstGroup = true


### PR DESCRIPTION
Co-authored-by: Or Fleisher <fleisher.or@gmail.com>

Seeing some React key errors thrown in the `hello-world-extension` before this fix.