### PR TITLE
Relax editable TS types to allow creating editable versions of all the JSX.IntrinsicElements elements.

### DIFF
--- a/packages/playground/src/shared/custom-editable-components/App.tsx
+++ b/packages/playground/src/shared/custom-editable-components/App.tsx
@@ -1,0 +1,33 @@
+import {editable as e, SheetProvider} from '@theatre/r3f'
+import {getProject} from '@theatre/core'
+import React from 'react'
+import {Canvas} from '@react-three/fiber'
+
+const EditablePoints = e('points', 'mesh')
+
+function App() {
+  return (
+    <div
+      style={{
+        height: '100vh',
+      }}
+    >
+      <Canvas
+        dpr={[1.5, 2]}
+        linear
+        gl={{preserveDrawingBuffer: true}}
+        frameloop="demand"
+      >
+        <SheetProvider sheet={getProject('Space').sheet('Scene')}>
+          <ambientLight intensity={0.75} />
+          <EditablePoints uniqueName="points">
+            <torusKnotGeometry args={[1, 0.3, 128, 64]} />
+            <meshNormalMaterial />
+          </EditablePoints>
+        </SheetProvider>
+      </Canvas>
+    </div>
+  )
+}
+
+export default App

--- a/packages/playground/src/shared/custom-editable-components/index.tsx
+++ b/packages/playground/src/shared/custom-editable-components/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import App from './App'
+import studio from '@theatre/studio'
+import extension from '@theatre/r3f/dist/extension'
+
+studio.extend(extension)
+studio.initialize()
+
+ReactDOM.render(<App />, document.getElementById('root'))

--- a/packages/r3f/src/main/editable.tsx
+++ b/packages/r3f/src/main/editable.tsx
@@ -14,8 +14,8 @@ const createEditable = <Keys extends keyof JSX.IntrinsicElements>(
   config: EditableFactoryConfig,
 ) => {
   const editable = <
-    T extends ComponentType<any> | Keys | 'primitive',
-    U extends T extends Keys ? T : Keys,
+    T extends ComponentType<any> | keyof JSX.IntrinsicElements | 'primitive',
+    U extends Keys,
   >(
     Component: T,
     type: T extends 'primitive' ? null : U,


### PR DESCRIPTION
**Solution 1** for the need to create ad-hoc editable r3f components outside what's defined in the schema.

This solution simply relaxes the typings of `editable` to enable doing this:

```tsx
const EditablePoints = editable('points', 'mesh')

<EditablePoints
  uniqueName="points"
>
  <torusKnotGeometry args={[1, 0.3, 128, 64]} />
  <meshNormalMaterial />
</EditablePoints>
```

This functionality was also available previously, I only relaxed the types to allow this without errors.

This is possible, since all the `type` parameter of `editable` does is tell theatre how to interpret props on these components in theatre's prop-type system. As long as a component's props are a superset of the ones required by another component's schema definition (like in this example points is compatible with mesh, since mesh defines the transform props, which points also has), this will work.