### PR TITLE
Enable hiding the reference window

### DIFF
--- a/packages/r3f/src/extension/components/ReferenceWindow/ReferenceWindow.tsx
+++ b/packages/r3f/src/extension/components/ReferenceWindow/ReferenceWindow.tsx
@@ -8,11 +8,8 @@ import styled, {keyframes} from 'styled-components'
 import {TiWarningOutline} from 'react-icons/ti'
 import noiseImageUrl from './noise-transparent.png'
 import useExtensionStore from '../../useExtensionStore'
-import {useVal} from '@theatre/react'
-import {getEditorSheetObject} from '../../editorStuff'
-import studio from '@theatre/studio'
 
-const Container = styled.div<{minified: boolean}>`
+const Container = styled.div<{minimized: boolean}>`
   position: relative;
   display: flex;
   justify-content: center;
@@ -20,7 +17,7 @@ const Container = styled.div<{minified: boolean}>`
   pointer-events: auto;
   cursor: pointer;
   overflow: hidden;
-  border-radius: ${({minified}) => (minified ? '2px' : '4px')};
+  border-radius: ${({minimized}) => (minimized ? '2px' : '4px')};
   box-shadow: 0 1px 1px rgba(0, 0, 0, 0.25), 0 2px 6px rgba(0, 0, 0, 0.15);
 `
 
@@ -76,13 +73,17 @@ const Warning = styled.div`
 interface ReferenceWindowProps {
   maxHeight: number
   maxWidth: number
+  minimized: boolean
+  onToggleMinified: () => void
 }
 
-const ReferenceWindow: VFC<ReferenceWindowProps> = ({maxHeight, maxWidth}) => {
+const ReferenceWindow: VFC<ReferenceWindowProps> = ({
+  maxHeight,
+  maxWidth,
+  minimized,
+  onToggleMinified,
+}) => {
   const canvasRef = useRef<HTMLCanvasElement>(null)
-
-  const minified =
-    useVal(getEditorSheetObject()?.props.viewport.showReferenceWindow) ?? true
 
   const [gl] = useExtensionStore((state) => [state.gl], shallow)
   const [ref, {width: origWidth, height: origHeight}] = useMeasure()
@@ -136,19 +137,13 @@ const ReferenceWindow: VFC<ReferenceWindowProps> = ({maxHeight, maxWidth}) => {
     }
   }, [gl, width, height, preserveDrawingBuffer])
 
-  const toggleVisibility = () => {
-    studio.transaction(({set}) => {
-      set(getEditorSheetObject()!.props.viewport.showReferenceWindow, !minified)
-    })
-  }
-
   return (
     <Container
-      minified={!minified}
-      onClick={toggleVisibility}
+      minimized={minimized}
+      onClick={onToggleMinified}
       style={{
-        width: !minified ? 32 : preserveDrawingBuffer ? `${width}px` : 'auto',
-        height: !minified ? 32 : preserveDrawingBuffer ? `${height}px` : 'auto',
+        width: minimized ? 32 : preserveDrawingBuffer ? `${width}px` : 'auto',
+        height: minimized ? 32 : preserveDrawingBuffer ? `${height}px` : 'auto',
       }}
     >
       {preserveDrawingBuffer ? (

--- a/packages/r3f/src/extension/components/SnapshotEditor.tsx
+++ b/packages/r3f/src/extension/components/SnapshotEditor.tsx
@@ -184,6 +184,10 @@ const SnapshotEditor: React.FC<{paneId: string}> = (props) => {
 
   if (!editorObject) return <></>
 
+  const referenceWindowVisibility =
+    useVal(getEditorSheetObject()?.props.viewport.referenceWindow) ??
+    'minimized'
+
   return (
     <root.div style={{overflow: 'hidden'}}>
       <StyleSheetManager disableVendorPrefixes>
@@ -192,12 +196,26 @@ const SnapshotEditor: React.FC<{paneId: string}> = (props) => {
           <Wrapper>
             <Overlay>
               <Tools ref={setToolsContainer} />
-              <ReferenceWindowContainer>
-                <ReferenceWindow
-                  maxHeight={Math.min(bounds.height * 0.3, 150)}
-                  maxWidth={Math.min(bounds.width * 0.3, 250)}
-                />
-              </ReferenceWindowContainer>
+              {referenceWindowVisibility !== 'hidden' && (
+                <ReferenceWindowContainer>
+                  <ReferenceWindow
+                    maxHeight={Math.min(bounds.height * 0.3, 150)}
+                    maxWidth={Math.min(bounds.width * 0.3, 250)}
+                    minimized={referenceWindowVisibility === 'minimized'}
+                    onToggleMinified={() => {
+                      studio.transaction(({set}) => {
+                        set(
+                          getEditorSheetObject()!.props.viewport
+                            .referenceWindow,
+                          referenceWindowVisibility === 'minimized'
+                            ? 'maximized'
+                            : 'minimized',
+                        )
+                      })
+                    }}
+                  />
+                </ReferenceWindowContainer>
+              )}
               {!sceneSnapshot && (
                 <WaitForSceneInitMessage>
                   The scene hasn't been initialized yet. It will appear in the

--- a/packages/r3f/src/extension/editorStuff.ts
+++ b/packages/r3f/src/extension/editorStuff.ts
@@ -22,9 +22,15 @@ const editorSheetObjectConfig = {
         },
         {as: 'menu', label: 'Shading'},
       ),
-      showReferenceWindow: types.boolean(true, {
-        label: 'Reference',
-      }),
+      referenceWindow: types.stringLiteral(
+        'minimized',
+        {
+          maximized: 'Maximized',
+          minimized: 'Minimized',
+          hidden: 'Hidden',
+        },
+        {as: 'menu', label: 'Reference Window'},
+      ),
       lighting: types.stringLiteral(
         'physical',
         {


### PR DESCRIPTION
The reference window's two previous states (minimized and maximized) are extended with a third, "hidden" state. Hiding can be set in the editor settings by selecting the R3F UI > Editor sheet object in the left sidebar.