### PR TITLE
Fix the hover states for the single tween editor

### DIFF
--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/KeyframeEditor/CurveEditorPopover/CurveEditorPopover.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/KeyframeEditor/CurveEditorPopover/CurveEditorPopover.tsx
@@ -279,8 +279,13 @@ const CurveEditorPopover: React.VFC<ICurveEditorPopoverProps> = (props) => {
       e.stopPropagation()
     }
   }
-  const onEasingOptionMouseOver = (item: {label: string; value: string}) =>
+  const onEasingOptionMouseOver = (item: {label: string; value: string}) => {
+    // Set the `textInputMode` to `auto` if it was `init` before
+    // to enable the easing previews
+    if (textInputMode === TextInputMode.init)
+      setTextInputMode(TextInputMode.auto)
     setPreview(item.value)
+  }
   const onEasingOptionMouseOut = () => setPreview(null)
   const onSelectEasingOption = (item: {label: string; value: string}) => {
     setTempValue(tempTransaction, allConnections, item.value)


### PR DESCRIPTION
Hover states don’t work in the single tween editor unless you modify the curve first.