### PR TITLE
Fix namespace and object with same name ordering in OutlinePanel

### DIFF
--- a/theatre/studio/src/panels/OutlinePanel/ObjectsList/ObjectsList.tsx
+++ b/theatre/studio/src/panels/OutlinePanel/ObjectsList/ObjectsList.tsx
@@ -39,41 +39,39 @@ function NamespaceTree(props: {
   return (
     <>
       {[...props.namespace.entries()].map(([label, {object, nested}]) => {
-        const children = (
+        const nestedChildrenElt = nested && (
+          <NamespaceTree
+            namespace={nested}
+            // Question: will there be key conflict if two components have the same labels?
+            key={'namespaceTree(' + label + ')'}
+            visualIndentation={props.visualIndentation + 1}
+          />
+        )
+        const sameNameElt = object && (
+          <ObjectItem
+            depth={props.visualIndentation}
+            // key is useful for navigating react dev component tree
+            key={'objectPath(' + object.address.objectKey + ')'}
+            // object entries should not allow this to be undefined
+            sheetObject={object}
+            overrideLabel={label}
+          />
+        )
+
+        return (
           <React.Fragment key={`${label} - ${props.visualIndentation}`}>
-            {object && (
-              <ObjectItem
+            {sameNameElt}
+            {nestedChildrenElt && (
+              <BaseItem
+                selectionStatus="not-selectable"
+                label={label}
+                // key necessary for no duplicate keys (next to other React.Fragments)
+                key={`baseItem(${label})`}
                 depth={props.visualIndentation}
-                // key is useful for navigating react dev component tree
-                key={'objectPath(' + object.address.objectKey + ')'}
-                // object entries should not allow this to be undefined
-                sheetObject={object}
-                overrideLabel={label}
-              />
-            )}
-            {nested && (
-              <NamespaceTree
-                namespace={nested}
-                // Question: will there be key conflict if two components have the same labels?
-                key={'namespaceTree(' + label + ')'}
-                visualIndentation={props.visualIndentation + 1}
+                children={nestedChildrenElt}
               />
             )}
           </React.Fragment>
-        )
-
-        return nested ? (
-          <BaseItem
-            selectionStatus="not-selectable"
-            label={label}
-            // key necessary for no duplicate keys (next to other React.Fragments)
-            key={`baseItem(${label})`}
-            depth={props.visualIndentation}
-            children={children}
-          />
-        ) : (
-          // if we don't have any nested items, just render the children with no wrapper, here.
-          children
         )
       })}
     </>


### PR DESCRIPTION
Fixes P-206 in Linear

Before

<img width="156" alt="Cole's screen capture of Playground – Theatre js 2022-07-21 at 14 00 48@2x" src="https://user-images.githubusercontent.com/2925395/180282687-e1e28241-32ce-4734-8fa7-d6e7a030a2d1.png">


After
<img width="200" alt="Cole's screen capture of Playground – Theatre js 2022-07-21 at 14 01 11@2x" src="https://user-images.githubusercontent.com/2925395/180282711-d5b8d18c-e87d-41e9-aa39-b4c2d644bf39.png">

