### PR TITLE
Use namespacing in the dom playground project

### DIFF
--- a/packages/playground/src/shared/dom/Scene.tsx
+++ b/packages/playground/src/shared/dom/Scene.tsx
@@ -223,7 +223,7 @@ export const Scene: React.FC<{project: IProject}> = ({project}) => {
       {boxes.map((id) => (
         <Box
           key={'box' + id}
-          id={id}
+          id={`Boxes/${id}`}
           sheet={sheet}
           selection={selection ?? []}
         />


### PR DESCRIPTION
To my best knowledge we only use namespacing in the r3f playground project, which might be unnecessarily hard to understand for people who are not familiar with r3f. I think it would be advantageous for us to include namespacing in the dom playground project which is the most accessible for a general audience.
