### PR TITLE
Fix compound props showing wrong control indicator

### DIFF
--- a/theatre/studio/src/propEditors/useEditingToolsForCompoundProp.tsx
+++ b/theatre/studio/src/propEditors/useEditingToolsForCompoundProp.tsx
@@ -101,7 +101,9 @@ export function useEditingToolsForCompoundProp<T extends SerializablePrimitive>(
       pathToProp,
     ) as undefined | IPropPathToTrackIdTree
 
-    const hasOneOrMoreSequencedTracks = !!possibleSequenceTrackIds
+    const hasOneOrMoreSequencedTracks =
+      possibleSequenceTrackIds !== undefined &&
+      Object.keys(possibleSequenceTrackIds).length !== 0 // check if object is empty or undefined
     const listOfDescendantTrackIds: SequenceTrackId[] = []
 
     let hasOneOrMoreStatics = true


### PR DESCRIPTION
https://linear.app/theatre/issue/P-205/props-can-be-shown-as-sequenced-even-if-no-child-props-are-sequenced