### PR TITLE
Apply common sense constraints to window drag and resize

### DIFF
--- a/theatre/studio/src/panels/BasePanel/PanelDragZone.tsx
+++ b/theatre/studio/src/panels/BasePanel/PanelDragZone.tsx
@@ -7,6 +7,8 @@ import React, {useMemo, useRef} from 'react'
 import styled from 'styled-components'
 import {panelDimsToPanelPosition, usePanel} from './BasePanel'
 import {useCssCursorLock} from '@theatre/studio/uiComponents/PointerEventsHandler'
+import {clamp} from 'lodash-es'
+import {visibleSize} from './common'
 
 const Container = styled.div`
   cursor: move;
@@ -35,8 +37,16 @@ const PanelDragZone: React.FC<
           onDrag(dx, dy) {
             const newDims: typeof panelStuff['dims'] = {
               ...stuffBeforeDrag.dims,
-              top: stuffBeforeDrag.dims.top + dy,
-              left: stuffBeforeDrag.dims.left + dx,
+              top: clamp(
+                stuffBeforeDrag.dims.top + dy,
+                0,
+                window.innerHeight - visibleSize,
+              ),
+              left: clamp(
+                stuffBeforeDrag.dims.left + dx,
+                -stuffBeforeDrag.dims.width + visibleSize,
+                window.innerWidth - visibleSize,
+              ),
             }
             const position = panelDimsToPanelPosition(newDims, {
               width: window.innerWidth,

--- a/theatre/studio/src/panels/BasePanel/PanelResizeHandle.tsx
+++ b/theatre/studio/src/panels/BasePanel/PanelResizeHandle.tsx
@@ -8,6 +8,8 @@ import React, {useMemo, useRef} from 'react'
 import styled from 'styled-components'
 import {panelDimsToPanelPosition, usePanel} from './BasePanel'
 import {pointerEventsAutoInNormalMode} from '@theatre/studio/css'
+import {clamp} from 'lodash-es'
+import {visibleSize} from './common'
 
 const Base = styled.div`
   position: absolute;
@@ -167,9 +169,13 @@ const PanelResizeHandle: React.FC<{
               )
             } else if (which.startsWith('Top')) {
               const bottom = newDims.top + newDims.height
-              const top = Math.min(
-                bottom - stuffBeforeDrag.minDims.height,
+              const top = clamp(
                 newDims.top + dy,
+                0,
+                Math.min(
+                  bottom - stuffBeforeDrag.minDims.height,
+                  window.innerHeight - visibleSize,
+                ),
               )
               const height = bottom - top
 
@@ -179,8 +185,11 @@ const PanelResizeHandle: React.FC<{
             if (which.endsWith('Left')) {
               const right = newDims.left + newDims.width
               const left = Math.min(
-                right - stuffBeforeDrag.minDims.width,
                 newDims.left + dx,
+                Math.min(
+                  right - stuffBeforeDrag.minDims.width,
+                  window.innerWidth - visibleSize,
+                ),
               )
               const width = right - left
 
@@ -189,7 +198,10 @@ const PanelResizeHandle: React.FC<{
             } else if (which.endsWith('Right')) {
               newDims.width = Math.max(
                 newDims.width + dx,
-                stuffBeforeDrag.minDims.width,
+                Math.max(
+                  stuffBeforeDrag.minDims.width,
+                  visibleSize - stuffBeforeDrag.dims.left,
+                ),
               )
             }
 

--- a/theatre/studio/src/panels/BasePanel/common.tsx
+++ b/theatre/studio/src/panels/BasePanel/common.tsx
@@ -59,3 +59,5 @@ export const TitleBar = styled.div`
   white-space: nowrap;
   text-overflow: ellipsis;
 `
+
+export const visibleSize = 100


### PR DESCRIPTION
This PR fixes the issue that extension windows can be dragged/resized in such a way that the drag area no longer falls inside the browser viewport and the window becomes impossible to move.