### PR TITLE
Remove useless TS type

### DIFF
--- a/packages/r3f/src/main/editable.tsx
+++ b/packages/r3f/src/main/editable.tsx
@@ -191,20 +191,18 @@ Then you can use it in your JSX like any other editable component. Note the make
     primitive: editable('primitive', null),
   } as unknown as {
     [Property in Keys]: React.ForwardRefExoticComponent<
-      React.PropsWithRef<
-        Omit<JSX.IntrinsicElements[Property], 'visible'> & {
-          theatreKey: string
-          visible?: boolean | 'editor'
-          additionalProps?: $FixMe
-          objRef?: $FixMe
-          // not exactly sure how to get the type of the threejs object itself
-          ref?: Ref<unknown>
-        }
-      >
+      Omit<JSX.IntrinsicElements[Property], 'visible'> & {
+        theatreKey: string
+        visible?: boolean | 'editor'
+        additionalProps?: $FixMe
+        objRef?: $FixMe
+        // not exactly sure how to get the type of the threejs object itself
+        ref?: Ref<unknown>
+      }
     >
   } & {
     primitive: React.ForwardRefExoticComponent<
-      React.PropsWithRef<{
+      {
         object: any
         theatreKey: string
         visible?: boolean | 'editor'
@@ -213,7 +211,7 @@ Then you can use it in your JSX like any other editable component. Note the make
         editableType: keyof JSX.IntrinsicElements
         // not exactly sure how to get the type of the threejs object itself
         ref?: Ref<unknown>
-      }> & {
+      } & {
         // Have to reproduce the primitive component's props here because we need to
         // lift this index type here to the outside to make auto-complete work
         [props: string]: any


### PR DESCRIPTION
This PR was originally going to fix TS incompatibilities with r3f v8, but that has since then been accidentally fixed.

However while inspecting the types I found out that what has been removed here made no difference in the output.