### PR TITLE
Experiment: Generator function API for prism (derive)

### DIFF
--- a/packages/dataverse/src/Atom.ts
+++ b/packages/dataverse/src/Atom.ts
@@ -10,6 +10,7 @@ import pointer, {getPointerMeta} from './pointer'
 import type {$FixMe, $IntentionalAny} from './types'
 import type {PathBasedReducer} from './utils/PathBasedReducer'
 import updateDeep from './utils/updateDeep'
+import Box from './Box'
 
 type Listener = (newVal: unknown) => void
 
@@ -323,5 +324,27 @@ export const val = <
     return input.getValue() as $IntentionalAny
   } else {
     return input as $IntentionalAny
+  }
+}
+
+export const toDerivation = <
+  P extends
+    | PointerType<$IntentionalAny>
+    | IDerivation<$IntentionalAny>
+    | undefined
+    | null,
+>(
+  input: P,
+): P extends PointerType<infer T>
+  ? IDerivation<T>
+  : P extends IDerivation<infer T>
+  ? IDerivation<T>
+  : IDerivation<P> => {
+  if (isPointer(input)) {
+    return valueDerivation(input) as $IntentionalAny
+  } else if (isDerivation(input)) {
+    return input as $IntentionalAny
+  } else {
+    return new Box(input).derivation as $IntentionalAny
   }
 }

--- a/packages/dataverse/src/derivations/AbstractDerivation.ts
+++ b/packages/dataverse/src/derivations/AbstractDerivation.ts
@@ -2,6 +2,7 @@ import type Ticker from '../Ticker'
 import type {$IntentionalAny, VoidFn} from '../types'
 import type Tappable from '../utils/Tappable'
 import DerivationEmitter from './DerivationEmitter'
+import DerivationEmitterTickerless from './DerivationEmitterTickerless'
 import DerivationValuelessEmitter from './DerivationValuelessEmitter'
 import flatMap from './flatMap'
 import type {IDerivation} from './IDerivation'
@@ -96,7 +97,12 @@ export default abstract class AbstractDerivation<V> implements IDerivation<V> {
   changesWithoutValues(): Tappable<void> {
     return new DerivationValuelessEmitter(this).tappable()
   }
-
+  onStaleWithoutValues(): Tappable<void> {
+    return new DerivationValuelessEmitter(this).tappable()
+  }
+  onStale(): Tappable<V> {
+    return new DerivationEmitterTickerless(this).tappable()
+  }
   /**
    * Keep the derivation hot, even if there are no tappers (subscribers).
    */

--- a/packages/dataverse/src/derivations/DerivationEmitterTickerless.ts
+++ b/packages/dataverse/src/derivations/DerivationEmitterTickerless.ts
@@ -8,9 +8,9 @@ import type {IDerivation} from './IDerivation'
  * this is that you have control over when the underlying derivation is freshened, it won't automatically be freshened
  * by the emitter.
  */
-export default class DerivationValuelessEmitter<V> {
+export default class DerivationValuelessEmitterTickerless<V> {
   _derivation: IDerivation<V>
-  _emitter: Emitter<void>
+  _emitter: Emitter<V>
   _hadTappers: boolean
 
   constructor(derivation: IDerivation<V>) {
@@ -23,8 +23,8 @@ export default class DerivationValuelessEmitter<V> {
     return this
   }
 
-  private _emit = () => {
-    this._emitter.emit()
+  private _emit = (derivation: IDerivation<V>) => {
+    this._emitter.emit(derivation.getValue())
   }
 
   _reactToNumberOfTappersChange() {
@@ -42,7 +42,7 @@ export default class DerivationValuelessEmitter<V> {
   /**
    * The tappable associated with the emitter. You can use it to tap (subscribe to) the underlying derivation.
    */
-  tappable(): Tappable<void> {
+  tappable(): Tappable<V> {
     return this._emitter.tappable
   }
 }

--- a/packages/dataverse/src/derivations/IDerivation.ts
+++ b/packages/dataverse/src/derivations/IDerivation.ts
@@ -19,17 +19,22 @@ export interface IDerivation<V> {
   isHot: boolean
 
   /**
-   * Returns a `Tappable` of the changes of this derivation.
+   * Returns a `Tappable` of the changes of this derivation. Only notifies when the
+   * ticker ticks and if the value of the derivation is different than previous.
    */
   changes(ticker: Ticker): Tappable<V>
 
   /**
+   * @deprecated use onStaleWithoutValues instead
    * Like {@link changes} but with a different performance model. `changesWithoutValues` returns a {@link Tappable} that
    * updates every time the derivation is updated, even if the value didn't change, and the callback is called without
    * the value. The advantage of this is that you have control over when the derivation is freshened, it won't
    * automatically be kept fresh.
    */
   changesWithoutValues(): Tappable<void>
+
+  onStaleWithoutValues(): Tappable<void>
+  onStale(): Tappable<V>
 
   /**
    * Keep the derivation hot, even if there are no tappers (subscribers).

--- a/packages/dataverse/src/derivations/derivationFunction/derivationFunction.test.ts
+++ b/packages/dataverse/src/derivations/derivationFunction/derivationFunction.test.ts
@@ -1,0 +1,225 @@
+/*
+ * @jest-environment jsdom
+ */
+import Atom, {val, valueDerivation} from '../../Atom'
+import Box from '../../Box'
+import Ticker from '../../Ticker'
+import type {$FixMe, $IntentionalAny} from '../../types'
+import ConstantDerivation from '../ConstantDerivation'
+import iterateAndCountTicks from '../iterateAndCountTicks'
+import derive, {DerivationFunctionDerivation} from './derivationFunction'
+
+describe('prism', () => {
+  let ticker: Ticker
+  beforeEach(() => {
+    ticker = new Ticker()
+  })
+
+  it('should work', () => {
+    const o = new Atom({foo: 'foo'})
+    const d = new DerivationFunctionDerivation(function* () {
+      return (yield o.pointer.foo) + 'boo'
+    })
+    expect(d.getValue()).toEqual('fooboo')
+
+    const changes: Array<$FixMe> = []
+    d.changes(ticker).tap((c) => {
+      changes.push(c)
+    })
+
+    o.reduceState(['foo'], () => 'foo2')
+    ticker.tick()
+    expect(changes).toMatchObject(['foo2boo'])
+  })
+  it('should only collect immediate dependencies', () => {
+    const aD = new ConstantDerivation(1)
+    const bD = aD.map((v) => v * 2)
+    const cD = derive(function* () {
+      return yield bD
+    })
+    expect(cD.getValue()).toEqual(2)
+    expect((cD as $IntentionalAny)._dependencies.size).toEqual(1)
+  })
+
+  describe('derive.ref()', () => {
+    it('should work', () => {
+      const theAtom: Atom<{n: number}> = new Atom({n: 2})
+
+      const box = new Box<{isEven: boolean} | undefined>(undefined)
+      const isEvenD = derive(function* () {
+        const currentN = val(theAtom.pointer.n)
+
+        const isEven = currentN % 2 === 0
+        if (box.get()?.isEven === isEven) {
+          return box.get()
+        } else {
+          box.set({isEven})
+          return box.get()
+        }
+      })
+
+      const iterator = iterateAndCountTicks(isEvenD)
+
+      theAtom.reduceState(['n'], () => 3)
+
+      expect(iterator.next().value).toMatchObject({
+        value: {isEven: false},
+        ticks: 0,
+      })
+      theAtom.reduceState(['n'], () => 5)
+      theAtom.reduceState(['n'], () => 7)
+      expect(iterator.next().value).toMatchObject({
+        value: {isEven: false},
+        ticks: 1,
+      })
+      theAtom.reduceState(['n'], () => 2)
+      theAtom.reduceState(['n'], () => 4)
+      expect(iterator.next().value).toMatchObject({
+        value: {isEven: true},
+        ticks: 1,
+      })
+      expect(iterator.next().value).toMatchObject({
+        value: {isEven: true},
+        ticks: 0,
+      })
+    })
+  })
+
+  describe('derive.effect()', () => {
+    it('should work', async () => {
+      let iteration = 0
+      const sequence: unknown[] = []
+      const deps = new Atom([])
+
+      const a = new Atom({letter: 'a'})
+
+      const derivation = derive(function* () {
+        const n = yield a.pointer.letter
+        const iterationAtTimeOfCall = iteration
+        sequence.push({derivationCall: iterationAtTimeOfCall})
+
+        const b = valueDerivation(deps.pointer).map((depVals) => {
+          sequence.push({effectCall: iterationAtTimeOfCall})
+          return () => {
+            sequence.push({cleanupCall: iterationAtTimeOfCall})
+          }
+        })
+
+        return n
+      })
+
+      const untap = derivation.changes(ticker).tap((change) => {
+        sequence.push({change})
+      })
+
+      expect(sequence).toMatchObject([{derivationCall: 0}, {effectCall: 0}])
+      sequence.length = 0
+
+      iteration++
+      a.setIn(['letter'], 'b')
+      ticker.tick()
+      expect(sequence).toMatchObject([{derivationCall: 1}, {change: 'b'}])
+      sequence.length = 0
+
+      deps = [1]
+      iteration++
+      a.setIn(['letter'], 'c')
+      ticker.tick()
+      expect(sequence).toMatchObject([
+        {derivationCall: 2},
+        {cleanupCall: 0},
+        {effectCall: 2},
+        {change: 'c'},
+      ])
+      sequence.length = 0
+
+      untap()
+
+      // takes a tick before untap takes effect
+      await new Promise((resolve) => setTimeout(resolve, 1))
+      expect(sequence).toMatchObject([{cleanupCall: 2}])
+    })
+  })
+
+  describe('derive.memo()', () => {
+    it('should work', async () => {
+      let iteration = 0
+      const sequence: unknown[] = []
+      let deps: unknown[] = []
+
+      const a = new Atom({letter: 'a'})
+
+      const derivation = derive(() => {
+        const n = val(a.pointer.letter)
+        const iterationAtTimeOfCall = iteration
+        sequence.push({derivationCall: iterationAtTimeOfCall})
+
+        const resultOfMemo = derive.memo(
+          'memo',
+          () => {
+            sequence.push({memoCall: iterationAtTimeOfCall})
+            return iterationAtTimeOfCall
+          },
+          [...deps],
+        )
+
+        sequence.push({resultOfMemo})
+
+        return n
+      })
+
+      const untap = derivation.changes(ticker).tap((change) => {
+        sequence.push({change})
+      })
+
+      expect(sequence).toMatchObject([
+        {derivationCall: 0},
+        {memoCall: 0},
+        {resultOfMemo: 0},
+      ])
+      sequence.length = 0
+
+      iteration++
+      a.setIn(['letter'], 'b')
+      ticker.tick()
+      expect(sequence).toMatchObject([
+        {derivationCall: 1},
+        {resultOfMemo: 0},
+        {change: 'b'},
+      ])
+      sequence.length = 0
+
+      deps = [1]
+      iteration++
+      a.setIn(['letter'], 'c')
+      ticker.tick()
+      expect(sequence).toMatchObject([
+        {derivationCall: 2},
+        {memoCall: 2},
+        {resultOfMemo: 2},
+        {change: 'c'},
+      ])
+      sequence.length = 0
+
+      untap()
+    })
+  })
+
+  describe(`derive.scope()`, () => {
+    it('should prevent name conflicts', () => {
+      const d = derive(() => {
+        const thisNameWillBeUsedForBothMemos = 'blah'
+        const a = derive.scope('a', () => {
+          return derive.memo(thisNameWillBeUsedForBothMemos, () => 'a', [])
+        })
+
+        const b = derive.scope('b', () => {
+          return derive.memo(thisNameWillBeUsedForBothMemos, () => 'b', [])
+        })
+
+        return {a, b}
+      })
+      expect(d.getValue()).toMatchObject({a: 'a', b: 'b'})
+    })
+  })
+})

--- a/packages/dataverse/src/derivations/derivationFunction/derivationFunction.ts
+++ b/packages/dataverse/src/derivations/derivationFunction/derivationFunction.ts
@@ -1,0 +1,101 @@
+import type {PointerType} from '@theatre/dataverse'
+import {toDerivation, val} from '../../Atom'
+import type {$IntentionalAny} from '../../types'
+import AbstractDerivation from '../AbstractDerivation'
+import type {IDerivation} from '../IDerivation'
+
+function some<T>(set: Set<T>, predicate: (item: T) => boolean): boolean {
+  for (const item of set) {
+    if (predicate(item)) return true
+  }
+  return false
+}
+
+type Val =
+  | PointerType<$IntentionalAny>
+  | IDerivation<$IntentionalAny>
+  | undefined
+  | null
+
+type DerivationFunction<V, P extends Val> = () => Iterator<
+  P,
+  V,
+  P extends PointerType<infer T>
+    ? T
+    : P extends IDerivation<infer T>
+    ? T
+    : P extends undefined | null
+    ? P
+    : unknown
+>
+
+// ref: https://github.com/tj/co
+export class DerivationFunctionDerivation<V> extends AbstractDerivation<V> {
+  protected _DependencyValueCache: Map<IDerivation<unknown>, unknown> =
+    new Map()
+  protected _possiblyStaleDeps = new Set<IDerivation<unknown>>()
+
+  constructor(readonly _fn: DerivationFunction<V, Val>) {
+    super()
+  }
+
+  _recalculate() {
+    const doesStaleDepExist = some(
+      this._possiblyStaleDeps,
+      (dep) => this._DependencyValueCache.get(dep) !== dep.getValue(),
+    )
+    this._possiblyStaleDeps.clear() // checked the deps so we know if they are stale or not
+    if (!doesStaleDepExist) return this._lastValue!
+
+    const newDeps: Set<IDerivation<unknown>> = new Set()
+    this._DependencyValueCache.clear()
+
+    let value: V
+    try {
+      const iter = this._fn()
+      let curr = iter.next()
+      while (!curr.done) {
+        const dep = toDerivation(curr.value)
+        newDeps.add(dep)
+        this._addDependency(dep)
+        curr = iter.next(val(dep))
+      }
+      value = curr.value
+    } catch (error) {
+      console.error(error)
+    }
+
+    // remove deps that were removed (why is this necessary?)
+    for (const dep of this._dependencies) {
+      if (!newDeps.has(dep)) {
+        this._removeDependency(dep)
+      }
+    }
+    this._dependencies = newDeps
+
+    for (const dep of newDeps) {
+      this._DependencyValueCache.set(dep, dep.getValue())
+    }
+
+    return value!
+  }
+
+  _reactToDependencyBecomingStale(msgComingFrom: IDerivation<unknown>) {
+    this._possiblyStaleDeps.add(msgComingFrom)
+  }
+
+  _keepHot() {
+    this.getValue()
+  }
+}
+
+/**
+ * Creates a derivation from the passed function that adds all derivations referenced
+ * in it as dependencies, and reruns the function when these change.
+ *
+ * @param fn - The function to rerun when the derivations referenced in it change.
+ */
+const derive = <V>(fn: DerivationFunction<V, Val>) =>
+  new DerivationFunctionDerivation(fn)
+
+export default derive

--- a/theatre/core/src/sequences/interpolationTripleAtPosition.ts
+++ b/theatre/core/src/sequences/interpolationTripleAtPosition.ts
@@ -65,14 +65,12 @@ function _forKeyframedTrack(
   track: BasicKeyframedTrack,
   timeD: IDerivation<number>,
 ): IDerivation<InterpolationTriple | undefined> {
+  let state: IState = {started: false}
   return prism(() => {
-    let stateRef = prism.ref<IState>('state', {started: false})
-    let state = stateRef.current
-
     const time = timeD.getValue()
 
     if (!state.started || time < state.validFrom || state.validTo <= time) {
-      stateRef.current = state = updateState(ctx, timeD, track)
+      state = updateState(ctx, timeD, track)
     }
 
     return state.der.getValue()


### PR DESCRIPTION
also change IDerivation methods:
- deprecate `changesWithoutValues`
- add `onStaleWithoutValues`
- add `onStale`

TODO: make code exmaple of `derive`

Open questions:
For the PR:
- how to replicate prism.memo, prism.effect, etc. using only derivations?
- can `derive` be more performant than `prism`? i.e. does using generator functions give an edge over using `discoveryMechansim`?

For myself:
- do atoms notify if references inside them change? Or only if values change?
- Can you use val inside of prism effect and memo? (I am almost sure but need to test)
- what is a good/simple mental model/heuristic for derivations? I still have trouble keeping track of hotness and freshness and what to worry about with them.