### PR TITLE
Add runtime type checks to r3f

### DIFF
--- a/packages/playground/src/shared/notifications/index.tsx
+++ b/packages/playground/src/shared/notifications/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import studio, {notify} from '@theatre/studio'
-import {getProject} from '@theatre/core'
+import studio from '@theatre/studio'
+import {getProject, notify} from '@theatre/core'
 import {Scene} from './Scene'
 
 studio.initialize()

--- a/packages/r3f/src/main/editableFactoryConfigUtils.ts
+++ b/packages/r3f/src/main/editableFactoryConfigUtils.ts
@@ -1,4 +1,5 @@
 import type {UnknownShorthandCompoundProps} from '@theatre/core'
+import {notify} from '@theatre/core'
 import {types} from '@theatre/core'
 import type {Object3D} from 'three'
 import type {IconID} from '../extension/icons'
@@ -77,11 +78,17 @@ export const createVectorPropConfig = (
           z: propValue.z,
         }
       : // show a warning and return defaultValue
-        (console.warn(
-          `Couldn't parse prop %c${key}={${JSON.stringify(
+        (notify.warning(
+          `Invalid value for vector prop "${key}"`,
+          `Couldn't make sense of \`${key}={${JSON.stringify(
             propValue,
-          )}}%c, falling back to default value.`,
-          'background: black; color: white',
+          )}}\`, falling back to \`${key}={${JSON.stringify([
+            defaultValue.x,
+            defaultValue.y,
+            defaultValue.z,
+          ])}}\`.
+
+To fix this, make sure the prop is set to either a number, an array of numbers, or a three.js Vector3 object.`,
         ),
         defaultValue)
     ;(['x', 'y', 'z'] as const).forEach((axis) => {

--- a/theatre/core/src/coreExports.ts
+++ b/theatre/core/src/coreExports.ts
@@ -15,6 +15,7 @@ import type {$IntentionalAny, VoidFn} from '@theatre/shared/utils/types'
 import coreTicker from './coreTicker'
 import type {ProjectId} from '@theatre/shared/utils/ids'
 import {_coreLogger} from './_coreLogger'
+export {notify} from '@theatre/shared/notify'
 export {types}
 
 /**

--- a/theatre/shared/src/notify.ts
+++ b/theatre/shared/src/notify.ts
@@ -2,7 +2,7 @@ import logger from './logger'
 import * as globalVariableNames from './globalVariableNames'
 
 export type Notification = {title: string; message: string}
-export type NotificationType = 'info' | 'success' | 'warning'
+export type NotificationType = 'info' | 'success' | 'warning' | 'error'
 export type Notify = (
   /**
    * The title of the notification.
@@ -37,13 +37,31 @@ export type Notifiers = {
    * Show an info notification.
    */
   info: Notify
+  /**
+   * Show an error notification.
+   */
+  error: Notify
 }
 
 const createHandler =
   (type: NotificationType): Notify =>
   (...args) => {
-    if (type === 'warning') {
-      logger.warn(args[1])
+    switch (type) {
+      case 'success': {
+        logger.debug(args.slice(0, 2).join('\n'))
+        break
+      }
+      case 'info': {
+        logger.debug(args.slice(0, 2).join('\n'))
+        break
+      }
+      case 'warning': {
+        logger.warn(args.slice(0, 2).join('\n'))
+        break
+      }
+      case 'error': {
+        // don't log errors, they're already logged by the browser
+      }
     }
 
     // @ts-ignore
@@ -54,4 +72,12 @@ export const notify: Notifiers = {
   warning: createHandler('warning'),
   success: createHandler('success'),
   info: createHandler('info'),
+  error: createHandler('error'),
 }
+
+window?.addEventListener('error', (e) => {
+  notify.error(
+    `An error occurred`,
+    `${e.message}\n\nSee **console** for details.`,
+  )
+})

--- a/theatre/studio/src/index.ts
+++ b/theatre/studio/src/index.ts
@@ -78,7 +78,6 @@ import {notify} from '@theatre/studio/notify'
 window[globalVariableNames.notifications] = {
   notify,
 }
-export {notify}
 
 export type {IScrub} from '@theatre/studio/Scrub'
 export type {

--- a/theatre/studio/src/notify.tsx
+++ b/theatre/studio/src/notify.tsx
@@ -135,6 +135,7 @@ const NotificationMessage = styled.div`
   }
 
   .code {
+    overflow: auto;
     font-family: monospace;
     background: rgba(0, 0, 0, 0.3);
     padding: 4px;
@@ -175,6 +176,7 @@ const COLORS = {
   info: '#3b82f6',
   success: '#10b981',
   warning: '#f59e0b',
+  error: '#ef4444',
 }
 
 const IndicatorDot = styled.div<{type: NotificationType}>`
@@ -214,7 +216,7 @@ const massageMessage = (message: string) => {
  * Creates handlers for different types of notifications.
  */
 const createHandler =
-  (type: 'warning' | 'success' | 'info'): Notify =>
+  (type: NotificationType): Notify =>
   (title, message, docs = [], allowDuplicates = false) => {
     // We can disallow duplicates. We do this through checking the notification contents
     // against a registry of already displayed notifications.
@@ -273,6 +275,7 @@ export const notify: Notifiers = {
   warning: createHandler('warning'),
   success: createHandler('success'),
   info: createHandler('info'),
+  error: createHandler('error'),
 }
 
 //region Styles


### PR DESCRIPTION
This PR also improves a couple things about the notification system, namely:
- notify is now exposed through @theatre/core instead of @theatre/studio. This way, production components of Theatre extensions (like r3f/main) can also easily make use of notifications without having to worry about studio being present, because @theatre/core already provides a fallback for them in case @theatre/studio is not present.
- You can now make error notifications
- An error notification is automatically fired on any thrown error, displaying the error message and directing users to the console