### PR TITLE
Fix default number nudge funcion

### DIFF
--- a/theatre/core/src/propTypes/index.ts
+++ b/theatre/core/src/propTypes/index.ts
@@ -651,7 +651,7 @@ const defaultNumberNudgeFn: NumberNudgeFn = ({
   magnitude,
 }) => {
   const {range} = config
-  if (range) {
+  if (range && !range.includes(Infinity) && !range.includes(-Infinity)) {
     return (
       deltaFraction * (range[1] - range[0]) * magnitude * config.nudgeMultiplier
     )


### PR DESCRIPTION
The current nudgle function doesn't account for `Infinity` values in `range`. This can often lead to incorrect behavior, since intuitively, to define a left-bounded input range that is unbounded on the right side, one would set `range` to e.g. `[0, Inifnity]`.