### PR TITLE
Add `nudgeIgnoreRange` opt to number type

### DIFF
--- a/packages/playground/src/shared/turtle/TurtleRenderer.tsx
+++ b/packages/playground/src/shared/turtle/TurtleRenderer.tsx
@@ -17,7 +17,11 @@ studio.initialize()
 
 const objConfig = {
   startingPoint: {
-    x: types.number(0.5, {range: [0, 1]}),
+    x: types.number(0.5, {
+      range: [-1, 1],
+      nudgeMultiplier: 0.1,
+      nudgeIgnoreRange: true,
+    }),
     y: types.number(0.5, {range: [0, 1]}),
   },
   scale: types.number(1, {range: [0.1, 1000]}),

--- a/theatre/core/src/propTypes/index.ts
+++ b/theatre/core/src/propTypes/index.ts
@@ -186,6 +186,7 @@ export const number = (
     range?: PropTypeConfig_Number['range']
     nudgeMultiplier?: number
     label?: string
+    nudgeIgnoreRange?: boolean
   } = {},
 ): PropTypeConfig_Number => {
   if (process.env.NODE_ENV !== 'production') {
@@ -635,6 +636,7 @@ export interface PropTypeConfig_Number
   range?: [min: number, max: number]
   nudgeFn: NumberNudgeFn
   nudgeMultiplier: number
+  nudgeIgnoreRange?: boolean
 }
 
 export type NumberNudgeFn = (p: {
@@ -651,7 +653,12 @@ const defaultNumberNudgeFn: NumberNudgeFn = ({
   magnitude,
 }) => {
   const {range} = config
-  if (range && !range.includes(Infinity) && !range.includes(-Infinity)) {
+  if (
+    !config.nudgeIgnoreRange &&
+    range &&
+    !range.includes(Infinity) &&
+    !range.includes(-Infinity)
+  ) {
     return (
       deltaFraction * (range[1] - range[0]) * magnitude * config.nudgeMultiplier
     )

--- a/theatre/studio/src/uiComponents/form/BasicNumberInput.tsx
+++ b/theatre/studio/src/uiComponents/form/BasicNumberInput.tsx
@@ -233,14 +233,13 @@ const BasicNumberInput: React.FC<{
       return {
         // note: we use mx because we need to constrain the `valueDuringDragging`
         // and dx will keep accumulating past any constraints
-        onDrag(_dx: number, _dy: number, e: MouseEvent, mx: number) {
-          const deltaX = e.altKey ? mx / 10 : mx
+        onDrag(_dragx: number, _dragy: number, e: MouseEvent, deltaX: number) {
           const newValue =
             valueDuringDragging +
             propsA.nudge({
               deltaX,
               deltaFraction: deltaX / inputWidth,
-              magnitude: 1,
+              magnitude: e.altKey ? 0.1 : 1,
             })
 
           valueDuringDragging = propsA.range


### PR DESCRIPTION
fixes #314 

@tomorrowevening and @clementroche were experiencing an issue (#314) where using `types.number` with `nudgeMultiplier` and `range` at the same time is behaving unexpectedly. I understand that the source of the unexpected behaviour is that the nudge is automatically scaled to the size of the `range`, which can make the nudgeMultiplier behave very differently for different `range`s. To fix this issue, I have added an additional `types.number` option `nudgeIgnoreRange` to disable this behaviour so that `nudgeMultiplier` results in the same nudge size regardless of the `range`.