### PR TITLE
document and simplify cache usage, SheetObject

### DIFF
--- a/packages/dataverse/src/PointerProxy.ts
+++ b/packages/dataverse/src/PointerProxy.ts
@@ -1,4 +1,4 @@
-import type {IdentityDerivationProvider} from './Atom'
+import * as Atom from './Atom'
 import type {Pointer} from './pointer'
 import pointer from './pointer'
 import type {IBox} from './Box'
@@ -14,12 +14,8 @@ import {valueDerivation} from './Atom'
  * to the proxied pointer too.
  */
 export default class PointerProxy<O extends {}>
-  implements IdentityDerivationProvider
+  implements Atom.PathedDerivable
 {
-  /**
-   * @internal
-   */
-  readonly $$isIdentityDerivationProvider = true
   private readonly _currentPointerBox: IBox<Pointer<O>>
   /**
    * Convenience pointer pointing to the root of this PointerProxy.
@@ -47,7 +43,7 @@ export default class PointerProxy<O extends {}>
    *
    * @param path - The path to create the derivation at.
    */
-  getIdentityDerivation(path: Array<string | number>) {
+  [Atom.pathedDerivation](path: Array<string | number>) {
     return this._currentPointerBox.derivation.flatMap((p) => {
       const subPointer = path.reduce(
         (pointerSoFar, pathItem) => (pointerSoFar as $IntentionalAny)[pathItem],

--- a/packages/dataverse/src/index.ts
+++ b/packages/dataverse/src/index.ts
@@ -4,7 +4,7 @@
  * @packageDocumentation
  */
 
-export type {IdentityDerivationProvider} from './Atom'
+export type {PathedDerivable} from './Atom'
 export {default as Atom, val, valueDerivation} from './Atom'
 export {default as Box} from './Box'
 export type {IBox} from './Box'

--- a/packages/dataverse/src/utils/updateDeep.ts
+++ b/packages/dataverse/src/utils/updateDeep.ts
@@ -2,11 +2,11 @@ import type {$FixMe, $IntentionalAny} from '../types'
 
 export default function updateDeep<S>(
   state: S,
-  path: (string | number | undefined)[],
+  path: (string | number)[],
   reducer: (...args: $IntentionalAny[]) => $IntentionalAny,
 ): S {
   if (path.length === 0) return reducer(state)
-  return hoop(state, path as $IntentionalAny, reducer)
+  return hoop(state, path, reducer)
 }
 
 const hoop = (

--- a/packages/playground/src/shared/turtle/index.tsx
+++ b/packages/playground/src/shared/turtle/index.tsx
@@ -8,6 +8,12 @@ import {getProject} from '@theatre/core'
 import type {ITurtle} from './turtle'
 import TurtleRenderer from './TurtleRenderer'
 import {useBoundingClientRect} from './utils'
+import getStudio from '@theatre/studio/getStudio'
+import type {
+  ObjectAddressKey,
+  ProjectId,
+  SheetId,
+} from '@theatre/shared/utils/ids'
 
 const project = getProject('Turtle Playground')
 
@@ -53,3 +59,15 @@ const TurtleExample: React.FC<{}> = (props) => {
 }
 
 render(<TurtleExample />, document.getElementById('root'))
+
+getStudio()!.transaction(({stateEditors}) => {
+  stateEditors.coreByProject.historic.sheetsById.expressionOverrides.byObject.setExpressionOfPrimitiveProp(
+    {
+      projectId: 'Turtle Playground' as ProjectId,
+      sheetId: 'Turtle' as SheetId,
+      objectKey: 'Renderer' as ObjectAddressKey,
+      pathToProp: ['startingPoint', 'x'],
+      expression: '(t) => t.startingPoint.y',
+    },
+  )
+})

--- a/packages/playground/src/shared/turtle/index.tsx
+++ b/packages/playground/src/shared/turtle/index.tsx
@@ -8,12 +8,8 @@ import {getProject} from '@theatre/core'
 import type {ITurtle} from './turtle'
 import TurtleRenderer from './TurtleRenderer'
 import {useBoundingClientRect} from './utils'
-import getStudio from '@theatre/studio/getStudio'
-import type {
-  ObjectAddressKey,
-  ProjectId,
-  SheetId,
-} from '@theatre/shared/utils/ids'
+
+
 
 const project = getProject('Turtle Playground')
 
@@ -59,15 +55,3 @@ const TurtleExample: React.FC<{}> = (props) => {
 }
 
 render(<TurtleExample />, document.getElementById('root'))
-
-getStudio()!.transaction(({stateEditors}) => {
-  stateEditors.coreByProject.historic.sheetsById.expressionOverrides.byObject.setExpressionOfPrimitiveProp(
-    {
-      projectId: 'Turtle Playground' as ProjectId,
-      sheetId: 'Turtle' as SheetId,
-      objectKey: 'Renderer' as ObjectAddressKey,
-      pathToProp: ['startingPoint', 'x'],
-      expression: '(t) => t.startingPoint.y',
-    },
-  )
-})

--- a/theatre/core/src/projects/store/types/SheetState_Historic.ts
+++ b/theatre/core/src/projects/store/types/SheetState_Historic.ts
@@ -21,6 +21,9 @@ export interface SheetState_Historic {
   staticOverrides: {
     byObject: StrictRecord<ObjectAddressKey, SerializableMap>
   }
+  // expressionOverrides?: {
+  //   byObject: StrictRecord<ObjectAddressKey, nestedStringOrSomething>
+  // }
   sequence?: HistoricPositionalSequence
 }
 

--- a/theatre/core/src/projects/store/types/SheetState_Historic.ts
+++ b/theatre/core/src/projects/store/types/SheetState_Historic.ts
@@ -21,9 +21,9 @@ export interface SheetState_Historic {
   staticOverrides: {
     byObject: StrictRecord<ObjectAddressKey, SerializableMap>
   }
-  // expressionOverrides?: {
-  //   byObject: StrictRecord<ObjectAddressKey, nestedStringOrSomething>
-  // }
+  expressionOverrides?: {
+    byObject: StrictRecord<ObjectAddressKey, SerializableMap>
+  }
   sequence?: HistoricPositionalSequence
 }
 

--- a/theatre/core/src/sequences/Sequence.ts
+++ b/theatre/core/src/sequences/Sequence.ts
@@ -17,6 +17,7 @@ import TheatreSequence from './TheatreSequence'
 import type {ILogger} from '@theatre/shared/logger'
 import type {ISequence} from '..'
 import {notify} from '@theatre/shared/notify'
+import * as Atom from '@theatre/dataverse/src/Atom'
 
 export type IPlaybackRange = [from: number, to: number]
 
@@ -44,7 +45,6 @@ export default class Sequence {
   _playableRangeD: undefined | IDerivation<{start: number; end: number}>
 
   readonly pointer: ISequence['pointer'] = pointer({root: this, path: []})
-  readonly $$isIdentityDerivationProvider = true
   readonly _logger: ILogger
 
   constructor(
@@ -79,7 +79,7 @@ export default class Sequence {
     )
   }
 
-  getIdentityDerivation(path: Array<string | number>): IDerivation<unknown> {
+  [Atom.pathedDerivation](path: Array<string | number>): IDerivation<unknown> {
     if (path.length === 0) {
       return prism((): ISequence['pointer']['$$__pointer_type'] => ({
         length: val(this.pointer.length),

--- a/theatre/core/src/sheetObjects/SheetObjectTemplate.test.ts
+++ b/theatre/core/src/sheetObjects/SheetObjectTemplate.test.ts
@@ -35,7 +35,7 @@ describe(`SheetObjectTemplate`, () => {
         },
       })
 
-      const iter = iterateOver(obj.template.getArrayOfValidSequenceTracks())
+      const iter = iterateOver(obj.template.validSequenceTracks)
 
       const validTracks = iter.next().value
       expect(validTracks).toHaveLength(1)
@@ -59,7 +59,7 @@ describe(`SheetObjectTemplate`, () => {
           tracksByObject: {},
         },
       })
-      const iter = iterateOver(obj.template.getArrayOfValidSequenceTracks())
+      const iter = iterateOver(obj.template.validSequenceTracks)
 
       expect(iter.next().value).toHaveLength(0)
     })

--- a/theatre/core/src/sheetObjects/SheetObjectTemplate.ts
+++ b/theatre/core/src/sheetObjects/SheetObjectTemplate.ts
@@ -150,6 +150,9 @@ export default class SheetObjectTemplate {
     const pointerToSheetState =
       this.project.pointers.historic.sheetsById[this.address.sheetId]
 
+    const expressionOverridesByPropPath = val(
+      pointerToSheetState.expressionOverrides.byObject[this.address.objectKey],
+    )
     const trackIdByPropPath = val(
       pointerToSheetState.sequence.tracksByObject[this.address.objectKey]
         .trackIdByPropPath,
@@ -169,6 +172,7 @@ export default class SheetObjectTemplate {
       const pathToProp = parsePathToProp(pathToPropInString)
       if (!pathToProp) continue
 
+      if (getDeep(expressionOverridesByPropPath ?? {}, pathToProp)) continue
       const propConfig = getPropConfigByPath(objectConfig, pathToProp)
 
       const isSequencable = propConfig && isPropConfSequencable(propConfig)

--- a/theatre/core/src/sheetObjects/TheatreSheetObject.ts
+++ b/theatre/core/src/sheetObjects/TheatreSheetObject.ts
@@ -148,10 +148,10 @@ export default class TheatreSheetObject<
   }
 
   private _valuesDerivation(): IDerivation<this['value']> {
-    return this._cache.get('onValuesChangeDerivation', () => {
+    return this._cache.getOrInit('onValuesChangeDerivation', () => {
       const sheetObject = privateAPI(this)
       const d: IDerivation<PropsValue<Props>> = prism(() => {
-        return val(sheetObject.getValues().getValue()) as $FixMe
+        return val(sheetObject.values.getValue()) as $FixMe
       })
       return d
     })

--- a/theatre/core/src/sheetObjects/TheatreSheetObject.ts
+++ b/theatre/core/src/sheetObjects/TheatreSheetObject.ts
@@ -151,7 +151,7 @@ export default class TheatreSheetObject<
     return this._cache.getOrInit('onValuesChangeDerivation', () => {
       const sheetObject = privateAPI(this)
       const d: IDerivation<PropsValue<Props>> = prism(() => {
-        return val(sheetObject.values.getValue()) as $FixMe
+        return val(sheetObject.values) as $FixMe
       })
       return d
     })

--- a/theatre/shared/src/utils/SimpleCache.ts
+++ b/theatre/shared/src/utils/SimpleCache.ts
@@ -4,11 +4,11 @@ export default class SimpleCache {
   protected _values: Record<string, unknown> = {}
   constructor() {}
 
-  get<T>(key: string, producer: () => T): T {
+  getOrInit<T>(key: string, initializer: () => T): T {
     if (this.has(key)) {
       return this._values[key] as $IntentionalAny
     } else {
-      const cachedValue = producer()
+      const cachedValue = initializer()
       this._values[key] = cachedValue
       return cachedValue
     }

--- a/theatre/shared/src/utils/deepMergeWithCache.ts
+++ b/theatre/shared/src/utils/deepMergeWithCache.ts
@@ -1,15 +1,20 @@
-import type {$IntentionalAny} from '@theatre/shared/utils/types'
 import type {DeepPartialOfSerializableValue, SerializableMap} from './types'
 
+/**
+ *
+ * say `base = {position: {x: 10}, rotation: {x: 0, y: 0, z: 0}}`
+ * and `override = {position: {x: 20}, rotation: {x: 0, y: 0, z: 0}}`
+ * then this function merges them while ensuring `base.rotation === override.rotation`
+ * i.e. it preserves referencial equality of objects in base as long as override's objects doesn't
+ * have different values.
+ *
+ */
 export default function deepMergeWithCache<T extends SerializableMap>(
   base: T,
   override: DeepPartialOfSerializableValue<T>,
-  cache: WeakMap<{}, unknown>,
+  cache: WeakMap<SerializableMap, {override: T; merged: T}>,
 ): T {
-  const _cache: WeakMap<SerializableMap, {override: T; merged: T}> =
-    cache as $IntentionalAny
-
-  const possibleCachedValue = _cache.get(base)
+  const possibleCachedValue = cache.get(base)
 
   if (possibleCachedValue && possibleCachedValue.override === override) {
     return possibleCachedValue.merged

--- a/theatre/studio/src/PaneManager.ts
+++ b/theatre/studio/src/PaneManager.ts
@@ -21,7 +21,7 @@ export default class PaneManager {
   }
 
   private _getAllPanes() {
-    return this._cache.get('_getAllPanels()', () =>
+    return this._cache.getOrInit('_getAllPanels()', () =>
       prism((): StrictRecord<PaneInstanceId, PaneInstance<string>> => {
         const core = val(this._studio.coreP)
         if (!core) return {}

--- a/theatre/studio/src/Studio.ts
+++ b/theatre/studio/src/Studio.ts
@@ -267,11 +267,13 @@ export class Studio {
   }
 
   getStudioProject(core: CoreExports): IProject {
-    return this._cache.get('getStudioProject', () => core.getProject('Studio'))
+    return this._cache.getOrInit('getStudioProject', () =>
+      core.getProject('Studio'),
+    )
   }
 
   getExtensionSheet(extensionId: string, core: CoreExports): ISheet {
-    return this._cache.get('extensionSheet-' + extensionId, () =>
+    return this._cache.getOrInit('extensionSheet-' + extensionId, () =>
       this.getStudioProject(core)!.sheet('Extension ' + extensionId),
     )
   }

--- a/theatre/studio/src/StudioStore/createTransactionPrivateApi.ts
+++ b/theatre/studio/src/StudioStore/createTransactionPrivateApi.ts
@@ -200,7 +200,7 @@ export default function createTransactionPrivateApi(
           .getValue()
 
         const defaultValue = getDeep(
-          root.template.getDefaultValues().getValue(),
+          root.template.defaultValues.getValue(),
           path,
         )
 

--- a/theatre/studio/src/TheatreStudio.ts
+++ b/theatre/studio/src/TheatreStudio.ts
@@ -411,7 +411,7 @@ export default class TheatreStudio implements IStudio {
   }
 
   private _getSelectionDerivation(): IDerivation<(ISheetObject | ISheet)[]> {
-    return this._cache.get('_getStateDerivation()', () =>
+    return this._cache.getOrInit('_getStateDerivation()', () =>
       prism((): (ISheetObject | ISheet)[] => {
         return getOutlineSelection()
           .filter(

--- a/theatre/studio/src/panels/DetailPanel/ProjectDetails.tsx
+++ b/theatre/studio/src/panels/DetailPanel/ProjectDetails.tsx
@@ -62,22 +62,16 @@ const ProjectDetails: React.FC<{
     }, 40000)
   }, [])
 
-  const exportTooltip = usePopover(
-    {debugName: 'ProjectDetails', pointerDistanceThreshold: 50},
-    () => (
-      <ExportTooltip>
-        This will create a JSON file with the state of your project. You can
-        commit this file to your git repo and include it in your production
-        bundle.
-        <a
-          href="https://docs.theatrejs.com/in-depth/#exporting"
-          target="_blank"
-        >
-          Here is a quick guide on how to export to production.
-        </a>
-      </ExportTooltip>
-    ),
-  )
+  const exportTooltip = usePopover({pointerDistanceThreshold: 50}, () => (
+    <ExportTooltip>
+      This will create a JSON file with the state of your project. You can
+      commit this file to your git repo and include it in your production
+      bundle.
+      <a href="https://docs.theatrejs.com/in-depth/#exporting" target="_blank">
+        Here is a quick guide on how to export to production.
+      </a>
+    </ExportTooltip>
+  ))
 
   return (
     <>

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/KeyframeEditor/useSingleKeyframeInlineEditorPopover.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/KeyframeEditor/useSingleKeyframeInlineEditorPopover.tsx
@@ -17,7 +17,7 @@ import type {UnknownValidCompoundProps} from '@theatre/core/propTypes/internals'
 export function useKeyframeInlineEditorPopover(
   props: EditingOptionsTree[] | null,
 ) {
-  return usePopover({debugName: 'useKeyframeInlineEditorPopover'}, () => (
+  return usePopover({}, () => (
     <BasicPopover showPopoverEdgeTriangle>
       <div style={{margin: '1px 2px 1px 10px'}}>
         {!Array.isArray(props)

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/LengthIndicator/LengthIndicator.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/LengthIndicator/LengthIndicator.tsx
@@ -142,7 +142,7 @@ const LengthIndicator: React.FC<IProps> = ({layoutP}) => {
     node: popoverNode,
     toggle: togglePopover,
     close: closePopover,
-  } = usePopover({debugName: 'LengthIndicator'}, () => {
+  } = usePopover({}, () => {
     return (
       <BasicPopover>
         <LengthEditorPopover layoutP={layoutP} onRequestClose={closePopover} />

--- a/theatre/studio/src/panels/SequenceEditorPanel/RightOverlay/Playhead.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/RightOverlay/Playhead.tsx
@@ -197,7 +197,7 @@ const Playhead: React.FC<{layoutP: Pointer<SequenceEditorPanelLayout>}> = ({
     node: popoverNode,
     toggle: togglePopover,
     close: closePopover,
-  } = usePopover({debugName: 'Playhead'}, () => {
+  } = usePopover({}, () => {
     return (
       <BasicPopover>
         <PlayheadPositionPopover

--- a/theatre/studio/src/propEditors/simpleEditors/RgbaPropEditor.tsx
+++ b/theatre/studio/src/propEditors/simpleEditors/RgbaPropEditor.tsx
@@ -75,7 +75,7 @@ function RgbaPropEditor({
     [editingTools],
   )
 
-  const popover = usePopover({debugName: 'RgbaPropEditor'}, () => (
+  const popover = usePopover({}, () => (
     <RgbaPopover>
       <RgbaColorPicker
         color={{

--- a/theatre/studio/src/propEditors/useEditingToolsForCompoundProp.tsx
+++ b/theatre/studio/src/propEditors/useEditingToolsForCompoundProp.tsx
@@ -3,9 +3,7 @@ import getStudio from '@theatre/studio/getStudio'
 import type {IContextMenuItem} from '@theatre/studio/uiComponents/simpleContextMenu/useContextMenu'
 import getDeep from '@theatre/shared/utils/getDeep'
 import {usePrism} from '@theatre/react'
-import type {
-  SerializablePrimitive,
-} from '@theatre/shared/utils/types'
+import type {SerializablePrimitive} from '@theatre/shared/utils/types'
 import {getPointerParts, prism, val} from '@theatre/dataverse'
 import type {Pointer} from '@theatre/dataverse'
 import get from 'lodash-es/get'

--- a/theatre/studio/src/propEditors/useEditingToolsForCompoundProp.tsx
+++ b/theatre/studio/src/propEditors/useEditingToolsForCompoundProp.tsx
@@ -4,7 +4,6 @@ import type {IContextMenuItem} from '@theatre/studio/uiComponents/simpleContextM
 import getDeep from '@theatre/shared/utils/getDeep'
 import {usePrism} from '@theatre/react'
 import type {
-  $IntentionalAny,
   SerializablePrimitive,
 } from '@theatre/shared/utils/types'
 import {getPointerParts, prism, val} from '@theatre/dataverse'
@@ -177,7 +176,7 @@ export function useEditingToolsForCompoundProp<T extends SerializablePrimitive>(
               stateEditors.coreByProject.historic.sheetsById.sequence.setPrimitivePropAsStatic(
                 {
                   ...propAddress,
-                  value: obj.getValueByPointer(pointerToSub as $IntentionalAny),
+                  value: val(pointerToSub) as SerializablePrimitive,
                 },
               )
             }

--- a/theatre/studio/src/propEditors/useEditingToolsForSimpleProp.tsx
+++ b/theatre/studio/src/propEditors/useEditingToolsForSimpleProp.tsx
@@ -285,7 +285,7 @@ function createDerivation<T extends SerializablePrimitive>(
       })
     }
 
-    const statics = val(obj.template.getStaticValues())
+    const statics = val(obj.template.staticValues)
 
     if (typeof getDeep(statics, pathToProp) !== 'undefined') {
       const ret: EditingToolsStatic<T> = {

--- a/theatre/studio/src/propEditors/useEditingToolsForSimpleProp.tsx
+++ b/theatre/studio/src/propEditors/useEditingToolsForSimpleProp.tsx
@@ -69,7 +69,7 @@ function createDerivation<T extends SerializablePrimitive>(
   return prism(() => {
     const pathToProp = getPointerParts(pointerToProp).path
 
-    const final = obj.getValueByPointer(pointerToProp) as T
+    const final = val(pointerToProp) as T
 
     const editPropValue = prism.memo(
       'editPropValue',
@@ -150,7 +150,7 @@ function createDerivation<T extends SerializablePrimitive>(
               stateEditors.coreByProject.historic.sheetsById.sequence.setPrimitivePropAsStatic(
                 {
                   ...propAddress,
-                  value: obj.getValueByPointer(pointerToProp) as T,
+                  value: val(pointerToProp) as T,
                 },
               )
             })

--- a/theatre/studio/src/store/stateEditors.ts
+++ b/theatre/studio/src/store/stateEditors.ts
@@ -970,7 +970,7 @@ namespace stateEditors {
 
             export function setExpressionOfPrimitiveProp(
               p: WithoutSheetInstance<PropAddress> & {
-                expression: string
+                expression: string | undefined
               },
             ) {
               set(_ensure(p), p.pathToProp, p.expression)

--- a/theatre/studio/src/uiComponents/Popover/usePopover.tsx
+++ b/theatre/studio/src/uiComponents/Popover/usePopover.tsx
@@ -40,7 +40,6 @@ const PopoverAutoCloseLock = React.createContext({
 })
 
 type Opts = {
-  debugName: string
   closeWhenPointerIsDistant?: boolean
   pointerDistanceThreshold?: number
   closeOnClickOutside?: boolean
@@ -64,8 +63,6 @@ export default function usePopover(
   opts: Opts | (() => Opts),
   render: () => React.ReactElement,
 ): IPopover {
-  const _debug = (...args: any) => {}
-
   // want to make sure that we don't close a popover when dragging something (like a curve editor handle)
   // I think this could be improved to handle closing after done dragging, better.
   const {isPointerBeingCaptured} = usePointerCapturing(`usePopover`)
@@ -77,7 +74,6 @@ export default function usePopover(
   const optsRef = useRef(opts)
 
   const close = useCallback<CloseFn>((reason: string): void => {
-    _debug(`closing due to "${reason}"`)
     stateRef.current = {isOpen: false}
   }, [])
 
@@ -130,7 +126,6 @@ export default function usePopover(
    * close a child popover.
    */
   const lock = useAutoCloseLockState({
-    _debug,
     state,
   })
 
@@ -178,20 +173,15 @@ export default function usePopover(
  * When child popovers are opened, we want to suspend all auto-closing
  * behaviors for parenting popovers.
  */
-function useAutoCloseLockState(options: {
-  state: State
-  _debug: (message: string, args?: object) => void
-}) {
+function useAutoCloseLockState(options: {state: State}) {
   const parentLock = useContext(PopoverAutoCloseLock)
 
   useEffect(() => {
     if (options.state.isOpen) {
       // when this "popover" is open, then take focus from parent
       const focused = parentLock.takeFocus()
-      options._debug('take focus')
       return () => {
         // when closed / unmounted, release focus
-        options._debug('release focus')
         focused.releaseFocus()
       }
     }


### PR DESCRIPTION
I was having quite a bit of trouble understanding the usages of the `SimpleCache` and `prism.memo` in `SheetObject.ts` and `SheetObjectTemplate.ts`. I have refactored to make the cache usage more explicit (lazy initialization) and documented. I have changed some `get___(): IDerivation<___>` methods into property getters to simplify code and help communicate that this is a single derivation and not getting a new derivation every time it is called/accessed. I also factored out a lot of logic in `getSequencedValues`.