### PR TITLE
Blur prop editors on unmount

### DIFF
--- a/theatre/studio/src/uiComponents/form/BasicNumberInput.tsx
+++ b/theatre/studio/src/uiComponents/form/BasicNumberInput.tsx
@@ -1,5 +1,6 @@
 import {clamp, isInteger, round} from 'lodash-es'
-import type {MutableRefObject} from 'react'
+import type {MutableRefObject} from 'react';
+import { useEffect} from 'react'
 import {useState} from 'react'
 import React, {useMemo, useRef} from 'react'
 import styled from 'styled-components'
@@ -276,6 +277,13 @@ const BasicNumberInput: React.FC<{
       onInputKeyDown,
       onClick,
       onFocus,
+    }
+  }, [])
+
+  // Call onBlur on unmount. Because technically it _is_ a blur, but also, otherwise edits wouldn't be committed.
+  useEffect(() => {
+    return () => {
+      callbacks.onBlur()
     }
   }, [])
 

--- a/theatre/studio/src/uiComponents/form/BasicStringInput.tsx
+++ b/theatre/studio/src/uiComponents/form/BasicStringInput.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components'
-import type {MutableRefObject} from 'react'
+import type {MutableRefObject} from 'react';
+import { useEffect} from 'react'
 import React, {useMemo, useRef} from 'react'
 import mergeRefs from 'react-merge-refs'
 import useRefAndState from '@theatre/studio/utils/useRefAndState'
@@ -166,6 +167,13 @@ const BasicStringInput: React.FC<{
       onInputKeyDown,
       onClick,
       onFocus,
+    }
+  }, [])
+
+  // Call onBlur on unmount. Because technically it _is_ a blur, but also, otherwise edits wouldn't be committed.
+  useEffect(() => {
+    return () => {
+      callbacks.onBlur()
     }
   }, [])
 


### PR DESCRIPTION
Fixes keyframe not updating when the user drags the pointer away from the inline keyframe editor. The editor unmounts without committing or discarding its temporary edits, which from then on lingers forever, preventing the display of any permanent edits from then on (temp actions are always applied after perm actions in the studio reducer). These permanent edits are, however, persisted, that's why all is fine upon reload.