### PR TITLE
Playground improvements

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -15,6 +15,13 @@
       "type": "shell",
       "command": "yarn tsc --build --watch ./devEnv/typecheck-all-projects/tsconfig.all.json",
       "problemMatcher": ["$tsc-watch"]
+    },
+    {
+      "type": "npm",
+      "script": "playground",
+      "problemMatcher": [],
+      "label": "Playground",
+      "detail": "yarn workspace playground run serve"
     }
   ]
 }

--- a/packages/playground/devEnv/home/ItemSectionWithPreviews.tsx
+++ b/packages/playground/devEnv/home/ItemSectionWithPreviews.tsx
@@ -15,9 +15,9 @@ export const ItemSectionWithPreviews = (props: {
           return (
             <ItemContainer key={`li-${moduleName}`}>
               <ItemLink href={href}>
-                <PreviewContainer>
+                {/* <PreviewContainer>
                   <iframe src={href} frameBorder="0" tabIndex={-1} />
-                </PreviewContainer>
+                </PreviewContainer> */}
                 <ItemDesc>
                   <h3>{moduleName}</h3>
                   <p>{href}</p>
@@ -80,9 +80,9 @@ const ItemContainer = styled.div`
 `
 
 const ItemListContainer = styled.div`
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
   gap: 1rem;
-  flex-wrap: wrap;
 
   margin-bottom: 2rem;
 `

--- a/packages/playground/devEnv/openForOS.ts
+++ b/packages/playground/devEnv/openForOS.ts
@@ -2,7 +2,7 @@ import {spawn} from 'child_process'
 
 export function openForOS(hostedAt: string) {
   const open = {
-    darwin: ['open'],
+    darwin: ['open', '-a', 'Google Chrome'],
     linux: ['xdg-open'],
     win32: ['cmd', '/c', 'start'],
   }


### PR DESCRIPTION
Remove previews (all those iframes made things suuuuper slow), add vs code task for easy launch, open in chrome by default (safari may be my default browser but I don't want to use it for debugging)