### PR TITLE
Fix project json export

### DIFF
--- a/theatre/studio/src/panels/DetailPanel/ProjectDetails.tsx
+++ b/theatre/studio/src/panels/DetailPanel/ProjectDetails.tsx
@@ -60,7 +60,7 @@ const ProjectDetails: React.FC<{
     setTimeout(() => {
       URL.revokeObjectURL(objUrl)
     }, 40000)
-  }, [])
+  }, [project, suggestedFileName])
 
   const exportTooltip = usePopover(
     {debugName: 'ProjectDetails', pointerDistanceThreshold: 50},


### PR DESCRIPTION
If you have multiple projects, no matter which one you try to export, you'll always end up with the same project JSON.

This is because the export function in the ProjectDetails React component was memoized with an incorrect dep list.