### PR TITLE
Feature: Custom RAFDrivers

### DIFF
--- a/packages/benchmarks/src/index.tsx
+++ b/packages/benchmarks/src/index.tsx
@@ -1,5 +1,5 @@
 // import studio from '@theatre/studio'
-import {getProject} from '@theatre/core'
+import {createRafDriver, getProject} from '@theatre/core'
 import type {
   UnknownShorthandCompoundProps,
   ISheet,
@@ -7,11 +7,11 @@ import type {
 } from '@theatre/core'
 // @ts-ignore
 import benchProject1State from './Bench project 1.theatre-project-state.json'
-import {Ticker} from '@theatre/dataverse'
-import {setCoreTicker} from '@theatre/core/coreTicker'
+import {setCoreRafDriver} from '@theatre/core/coreTicker'
 
-const ticker = new Ticker()
-setCoreTicker(ticker)
+const driver = createRafDriver({name: 'BenchmarkRafDriver'})
+
+setCoreRafDriver(driver)
 
 // studio.initialize({})
 
@@ -79,7 +79,7 @@ async function test1() {
   }
 
   function iterateOnSequence() {
-    ticker.tick()
+    driver.tick(performance.now())
     const startTime = performance.now()
     for (let i = 1; i < CONFIG.numberOfIterations; i++) {
       onChangeEventsFired = 0
@@ -87,7 +87,7 @@ async function test1() {
       for (const sheet of sheets) {
         sheet.sequence.position = pos
       }
-      ticker.tick()
+      driver.tick(performance.now())
       if (onChangeEventsFired !== objects.length) {
         console.info(
           `Expected ${objects.length} onChange events, got ${onChangeEventsFired}`,

--- a/packages/dataverse/src/Ticker.ts
+++ b/packages/dataverse/src/Ticker.ts
@@ -1,6 +1,14 @@
 type ICallback = (t: number) => void
 
 /**
+ * The number of ticks that can pass without any scheduled callbacks before the Ticker goes dormant. This is to prevent
+ * the Ticker from staying active forever, even if there are no scheduled callbacks.
+ *
+ * Perhaps counting ticks vs. time is not the best way to do this. But it's a start.
+ */
+const EMPTY_TICKS_BEFORE_GOING_DORMANT = 60 /*fps*/ * 3 /*seconds*/ // on a 60fps screen, 3 seconds should pass before the ticker goes dormant
+
+/**
  * The Ticker class helps schedule callbacks. Scheduled callbacks are executed per tick. Ticks can be triggered by an
  * external scheduling strategy, e.g. a raf.
  */
@@ -9,6 +17,20 @@ export default class Ticker {
   private _scheduledForNextTick: Set<ICallback>
   private _timeAtCurrentTick: number
   private _ticking: boolean = false
+
+  /**
+   * Whether the Ticker is dormant
+   */
+  private _dormant: boolean = true
+
+  private _numberOfDormantTicks = 0
+
+  /**
+   * Whether the Ticker is dormant
+   */
+  get dormant(): boolean {
+    return this._dormant
+  }
   /**
    * Counts up for every tick executed.
    * Internally, this is used to measure ticks per second.
@@ -18,7 +40,18 @@ export default class Ticker {
    */
   public __ticks = 0
 
-  constructor() {
+  constructor(
+    private _conf?: {
+      /**
+       * This is called when the Ticker goes dormant.
+       */
+      onDormant?: () => void
+      /**
+       * This is called when the Ticker goes active.
+       */
+      onActive?: () => void
+    },
+  ) {
     this._scheduledForThisOrNextTick = new Set()
     this._scheduledForNextTick = new Set()
     this._timeAtCurrentTick = 0
@@ -40,6 +73,9 @@ export default class Ticker {
    */
   onThisOrNextTick(fn: ICallback) {
     this._scheduledForThisOrNextTick.add(fn)
+    if (this._dormant) {
+      this._goActive()
+    }
   }
 
   /**
@@ -52,6 +88,9 @@ export default class Ticker {
    */
   onNextTick(fn: ICallback) {
     this._scheduledForNextTick.add(fn)
+    if (this._dormant) {
+      this._goActive()
+    }
   }
 
   /**
@@ -86,6 +125,19 @@ export default class Ticker {
     } else return performance.now()
   }
 
+  private _goActive() {
+    if (!this._dormant) return
+    this._dormant = false
+    this._conf?.onActive?.()
+  }
+
+  private _goDormant() {
+    if (this._dormant) return
+    this._dormant = true
+    this._numberOfDormantTicks = 0
+    this._conf?.onDormant?.()
+  }
+
   /**
    * Triggers a tick which starts executing the callbacks scheduled for this tick.
    *
@@ -104,6 +156,19 @@ export default class Ticker {
     }
 
     this.__ticks++
+
+    if (!this._dormant) {
+      if (
+        this._scheduledForNextTick.size === 0 &&
+        this._scheduledForThisOrNextTick.size === 0
+      ) {
+        this._numberOfDormantTicks++
+        if (this._numberOfDormantTicks >= EMPTY_TICKS_BEFORE_GOING_DORMANT) {
+          this._goDormant()
+          return
+        }
+      }
+    }
 
     this._ticking = true
     this._timeAtCurrentTick = t

--- a/packages/dataverse/src/Ticker.ts
+++ b/packages/dataverse/src/Ticker.ts
@@ -1,40 +1,10 @@
 type ICallback = (t: number) => void
 
-function createRafTicker() {
-  const ticker = new Ticker()
-
-  if (typeof window !== 'undefined') {
-    /**
-     * @remarks
-     * TODO users should also be able to define their own ticker.
-     */
-    const onAnimationFrame = (t: number) => {
-      ticker.tick(t)
-      window.requestAnimationFrame(onAnimationFrame)
-    }
-    window.requestAnimationFrame(onAnimationFrame)
-  } else {
-    ticker.tick(0)
-    setTimeout(() => ticker.tick(1), 0)
-  }
-
-  return ticker
-}
-
-let rafTicker: undefined | Ticker
-
 /**
  * The Ticker class helps schedule callbacks. Scheduled callbacks are executed per tick. Ticks can be triggered by an
  * external scheduling strategy, e.g. a raf.
  */
 export default class Ticker {
-  /** Get a shared `requestAnimationFrame` ticker. */
-  static get raf(): Ticker {
-    if (!rafTicker) {
-      rafTicker = createRafTicker()
-    }
-    return rafTicker
-  }
   private _scheduledForThisOrNextTick: Set<ICallback>
   private _scheduledForNextTick: Set<ICallback>
   private _timeAtCurrentTick: number

--- a/packages/playground/src/shared/custom-raf-driver/App.tsx
+++ b/packages/playground/src/shared/custom-raf-driver/App.tsx
@@ -1,0 +1,36 @@
+import {editable as e, RafDriverProvider, SheetProvider} from '@theatre/r3f'
+import type {IRafDriver} from '@theatre/core'
+import {getProject} from '@theatre/core'
+import React from 'react'
+import {Canvas} from '@react-three/fiber'
+
+const EditablePoints = e('points', 'mesh')
+
+function App(props: {rafDriver: IRafDriver}) {
+  return (
+    <div
+      style={{
+        height: '100vh',
+      }}
+    >
+      <Canvas
+        dpr={[1.5, 2]}
+        linear
+        gl={{preserveDrawingBuffer: true}}
+        frameloop="demand"
+      >
+        <SheetProvider sheet={getProject('Space').sheet('Scene')}>
+          <RafDriverProvider driver={props.rafDriver}>
+            <ambientLight intensity={0.75} />
+            <EditablePoints theatreKey="points">
+              <torusKnotGeometry args={[1, 0.3, 128, 64]} />
+              <meshNormalMaterial />
+            </EditablePoints>
+          </RafDriverProvider>
+        </SheetProvider>
+      </Canvas>
+    </div>
+  )
+}
+
+export default App

--- a/packages/playground/src/shared/custom-raf-driver/index.tsx
+++ b/packages/playground/src/shared/custom-raf-driver/index.tsx
@@ -12,7 +12,7 @@ setInterval(() => {
 
 studio.extend(extension)
 studio.initialize({
-  rafDriver,
+  __experimental_rafDriver: rafDriver,
 })
 
 ReactDOM.render(<App rafDriver={rafDriver} />, document.getElementById('root'))

--- a/packages/playground/src/shared/custom-raf-driver/index.tsx
+++ b/packages/playground/src/shared/custom-raf-driver/index.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import App from './App'
+import studio from '@theatre/studio'
+import extension from '@theatre/r3f/dist/extension'
+import {createRafDriver} from '@theatre/core'
+
+const rafDriver = createRafDriver({name: 'a custom 5fps raf driver'})
+setInterval(() => {
+  rafDriver.tick(performance.now())
+}, 200)
+
+studio.extend(extension)
+studio.initialize({
+  rafDriver,
+})
+
+ReactDOM.render(<App rafDriver={rafDriver} />, document.getElementById('root'))

--- a/packages/playground/src/shared/hello-world-extension-dataverse/index.tsx
+++ b/packages/playground/src/shared/hello-world-extension-dataverse/index.tsx
@@ -4,7 +4,8 @@ import App from './App'
 import type {ToolsetConfig} from '@theatre/studio'
 import studio from '@theatre/studio'
 import extension from '@theatre/r3f/dist/extension'
-import {Atom, prism, Ticker, val} from '@theatre/dataverse'
+import {Atom, prism, val} from '@theatre/dataverse'
+import {onChange} from '@theatre/core'
 
 /**
  * Let's take a look at how we can use `prism`, `Ticker`, and `val` from Theatre.js's Dataverse library
@@ -28,41 +29,39 @@ studio.extend({
     global(set, studio) {
       const exampleBox = new Atom('mobile')
 
-      const untapFn = prism<ToolsetConfig>(() => [
-        {
-          type: 'Switch',
-          value: val(exampleBox.prism),
-          onChange: (value) => exampleBox.set(value),
-          options: [
-            {
-              value: 'mobile',
-              label: 'view mobile version',
-              svgSource: '😀',
-            },
-            {
-              value: 'desktop',
-              label: 'view desktop version',
-              svgSource: '🪢',
-            },
-          ],
-        },
-        {
-          type: 'Icon',
-          title: 'Example Icon',
-          svgSource: '👁‍🗨',
-          onClick: () => {
-            console.log('hello')
+      const untapFn = onChange(
+        prism<ToolsetConfig>(() => [
+          {
+            type: 'Switch',
+            value: val(exampleBox.prism),
+            onChange: (value) => exampleBox.set(value),
+            options: [
+              {
+                value: 'mobile',
+                label: 'view mobile version',
+                svgSource: '😀',
+              },
+              {
+                value: 'desktop',
+                label: 'view desktop version',
+                svgSource: '🪢',
+              },
+            ],
           },
-        },
-      ])
-        // listen to changes to this prism using the requestAnimationFrame shared ticker
-        .onChange(
-          Ticker.raf,
-          (value) => {
-            set(value)
+          {
+            type: 'Icon',
+            title: 'Example Icon',
+            svgSource: '👁‍🗨',
+            onClick: () => {
+              console.log('hello')
+            },
           },
-          true,
-        )
+        ]),
+        (value) => {
+          set(value)
+        },
+      )
+      // listen to changes to this prism using the requestAnimationFrame shared ticker
 
       return untapFn
     },

--- a/packages/playground/src/tests/r3f-stress-test/index.tsx
+++ b/packages/playground/src/tests/r3f-stress-test/index.tsx
@@ -3,14 +3,16 @@ import ReactDOM from 'react-dom'
 import App from './App'
 import studio from '@theatre/studio'
 import extension from '@theatre/r3f/dist/extension'
-import {Ticker} from '@theatre/dataverse'
+import getStudio from '@theatre/studio/getStudio'
+
+const studioPrivate = getStudio()
 
 studio.extend(extension)
 studio.initialize()
 
 ReactDOM.render(<App />, document.getElementById('root'))
 
-const raf = Ticker.raf
+const raf = studioPrivate.ticker
 
 // Show "ticks per second" information in performance measurements using the User Timing API
 // See https://developer.mozilla.org/en-US/docs/Web/API/User_Timing_API

--- a/packages/r3f/src/extension/index.ts
+++ b/packages/r3f/src/extension/index.ts
@@ -1,11 +1,12 @@
 import SnapshotEditor from './components/SnapshotEditor'
 import type {IExtension} from '@theatre/studio'
-import {prism, Ticker, val} from '@theatre/dataverse'
+import {prism, val} from '@theatre/dataverse'
 import {getEditorSheetObject} from './editorStuff'
 import ReactDOM from 'react-dom'
 import React from 'react'
 import type {ToolsetConfig} from '@theatre/studio'
 import useExtensionStore from './useExtensionStore'
+import {onChange} from '@theatre/core'
 
 const io5CameraOutline = `<svg xmlns="http://www.w3.org/2000/svg" class="ionicon" viewBox="0 0 512 512"><title>Camera</title><path d="M350.54 148.68l-26.62-42.06C318.31 100.08 310.62 96 302 96h-92c-8.62 0-16.31 4.08-21.92 10.62l-26.62 42.06C155.85 155.23 148.62 160 140 160H80a32 32 0 00-32 32v192a32 32 0 0032 32h352a32 32 0 0032-32V192a32 32 0 00-32-32h-59c-8.65 0-16.85-4.77-22.46-11.32z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="32"/><circle cx="256" cy="272" r="80" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="32"/><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="32" d="M124 158v-22h-24v22"/></svg>`
 const gameIconMove = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M256 34.47l-90.51 90.51h67.883v108.393H124.98V165.49L34.47 256l90.51 90.51v-67.883h108.393V387.02H165.49L256 477.53l90.51-90.51h-67.883V278.627H387.02v67.883L477.53 256l-90.51-90.51v67.883H278.627V124.98h67.883L256 34.47z"/></svg>`
@@ -35,13 +36,9 @@ const r3fExtension: IExtension = {
           },
         ]
       })
-      return calc.onChange(
-        Ticker.raf,
-        () => {
-          set(calc.getValue())
-        },
-        true,
-      )
+      return onChange(calc, () => {
+        set(calc.getValue())
+      })
     },
     'snapshot-editor': (set, studio) => {
       const {createSnapshot} = useExtensionStore.getState()
@@ -140,13 +137,9 @@ const r3fExtension: IExtension = {
           },
         ]
       })
-      return calc.onChange(
-        Ticker.raf,
-        () => {
-          set(calc.getValue())
-        },
-        true,
-      )
+      return onChange(calc, () => {
+        set(calc.getValue())
+      })
     },
   },
   panes: [

--- a/packages/r3f/src/index.ts
+++ b/packages/r3f/src/index.ts
@@ -21,6 +21,10 @@ export {
 export {makeStoreKey as __private_makeStoreKey} from './main/utils'
 
 export {default as SheetProvider, useCurrentSheet} from './main/SheetProvider'
+export {
+  default as RafDriverProvider,
+  useCurrentRafDriver,
+} from './main/RafDriverProvider'
 export {refreshSnapshot} from './main/utils'
 export {default as RefreshSnapshot} from './main/RefreshSnapshot'
 export * from './drei'

--- a/packages/r3f/src/main/RafDriverProvider.tsx
+++ b/packages/r3f/src/main/RafDriverProvider.tsx
@@ -1,0 +1,26 @@
+import type {ReactNode} from 'react'
+import React, {createContext, useContext, useEffect} from 'react'
+import type {IRafDriver} from '@theatre/core'
+
+const ctx = createContext<{rafDriver: IRafDriver}>(undefined!)
+
+export const useCurrentRafDriver = (): IRafDriver | undefined => {
+  return useContext(ctx)?.rafDriver
+}
+
+const RafDriverProvider: React.FC<{
+  driver: IRafDriver
+  children: ReactNode
+}> = ({driver, children}) => {
+  useEffect(() => {
+    if (!driver || driver.type !== 'Theatre_RafDriver_PublicAPI') {
+      throw new Error(
+        `driver in <RafDriverProvider deriver={driver}> has an invalid value`,
+      )
+    }
+  }, [driver])
+
+  return <ctx.Provider value={{rafDriver: driver}}>{children}</ctx.Provider>
+}
+
+export default RafDriverProvider

--- a/packages/r3f/src/main/editable.tsx
+++ b/packages/r3f/src/main/editable.tsx
@@ -11,6 +11,7 @@ import {makeStoreKey} from './utils'
 import type {$FixMe, $IntentionalAny} from '../types'
 import type {ISheetObject} from '@theatre/core'
 import {notify} from '@theatre/core'
+import {useCurrentRafDriver} from './RafDriverProvider'
 
 const createEditable = <Keys extends keyof JSX.IntrinsicElements>(
   config: EditableFactoryConfig,
@@ -74,6 +75,7 @@ const createEditable = <Keys extends keyof JSX.IntrinsicElements>(
         const objectRef = useRef<JSX.IntrinsicElements[U]>()
 
         const sheet = useCurrentSheet()!
+        const rafDriver = useCurrentRafDriver()
 
         const [sheetObject, setSheetObject] = useState<
           undefined | ISheetObject<$FixMe>
@@ -211,15 +213,18 @@ Then you can use it in your JSX like any other editable component. Note the make
 
           setFromTheatre(sheetObject.value)
 
-          const untap = sheetObject.onValuesChange(setFromTheatre)
+          const unsubscribe = sheetObject.onValuesChange(
+            setFromTheatre,
+            rafDriver,
+          )
 
           return () => {
-            untap()
+            unsubscribe()
             sheetObject.sheet.detachObject(theatreKey)
             allRegisteredObjects.delete(sheetObject)
             editorStore.getState().removeEditable(storeKey)
           }
-        }, [sheetObject])
+        }, [sheetObject, rafDriver])
 
         return (
           // @ts-ignore

--- a/theatre/core/src/CoreBundle.ts
+++ b/theatre/core/src/CoreBundle.ts
@@ -2,11 +2,13 @@ import type {Studio} from '@theatre/studio/Studio'
 import projectsSingleton from './projects/projectsSingleton'
 import {privateAPI} from './privateAPIs'
 import * as coreExports from './coreExports'
+import {getCoreRafDriver} from './coreTicker'
 
 export type CoreBits = {
   projectsP: typeof projectsSingleton.atom.pointer.projects
   privateAPI: typeof privateAPI
   coreExports: typeof coreExports
+  getCoreRafDriver: typeof getCoreRafDriver
 }
 
 export default class CoreBundle {
@@ -30,6 +32,7 @@ export default class CoreBundle {
       projectsP: projectsSingleton.atom.pointer.projects,
       privateAPI: privateAPI,
       coreExports,
+      getCoreRafDriver,
     }
 
     callback(bits)

--- a/theatre/core/src/coreExports.ts
+++ b/theatre/core/src/coreExports.ts
@@ -8,8 +8,7 @@ import {InvalidArgumentError} from '@theatre/shared/utils/errors'
 import {validateName} from '@theatre/shared/utils/sanitizers'
 import userReadableTypeOfValue from '@theatre/shared/utils/userReadableTypeOfValue'
 import deepEqual from 'fast-deep-equal'
-import type {PointerType} from '@theatre/dataverse';
-import { Ticker} from '@theatre/dataverse'
+import type {PointerType} from '@theatre/dataverse'
 import {isPointer} from '@theatre/dataverse'
 import {isPrism, pointerToPrism} from '@theatre/dataverse'
 import type {$IntentionalAny, VoidFn} from '@theatre/shared/utils/types'
@@ -18,6 +17,8 @@ import {_coreLogger} from './_coreLogger'
 import {getCoreTicker} from './coreTicker'
 export {notify} from '@theatre/shared/notify'
 export {types}
+export {createRafDriver} from './rafDrivers'
+export type {IRafDriver} from './rafDrivers'
 
 /**
  * Returns a project of the given id, or creates one if it doesn't already exist.
@@ -165,65 +166,6 @@ export function onChange<P extends PointerType<$IntentionalAny>>(
       `Called onChange(p) where p is neither a pointer nor a prism.`,
     )
   }
-}
-
-interface RafDriver {
-  id: number
-  state: 'stopped' | 'running'
-  stop: null | VoidFn
-  start: (tick: (t: number) => void) => void
-}
-
-let lastDriverId = 0
-// creates a custom request animation frame driver with a stop function
-function createRafDriver(
-  startFn: (tick: (t: number) => void) => undefined | (() => void),
-) {
-  const driver: RafDriver = {
-    id: lastDriverId++,
-    state: 'stopped' as 'stopped' | 'running',
-    stop: null as null | VoidFn,
-    start: (tick) => {
-      const stop = startFn(tick)
-      driver.stop = () => {
-        if (stop) {
-          driver.state = 'stopped'
-          stop()
-        }
-      }
-      driver.state = 'running'
-    },
-  }
-}
-
-createRafDriver(function startTicking(tick) {
-  let rafId: number
-  function loop() {
-    tick(performance.now())
-    rafId = requestAnimationFrame(loop)
-  }
-  rafId = requestAnimationFrame(loop)
-
-  return function stopTicking() {
-    cancelAnimationFrame(rafId)
-  }
-})
-
-const tickerDriverMap = new WeakMap<unknown, Ticker>()
-
-function createSimplerRafDriver(conf?: {
-  name?: string
-  start?: () => void
-  stop?: () => void
-}): {tick: (time: number) => void; name: string; id: number} {
-  const tick = (time: number): void => {}
-
-  const ticker = new Ticker()
-
-  const driver = {tick, id: lastDriverId++, name: conf?.name ?? ''}
-  tickerDriverMap.set(driver, ticker)
-
-  return driver
 }
 
 /**

--- a/theatre/core/src/privateAPIs.ts
+++ b/theatre/core/src/privateAPIs.ts
@@ -8,6 +8,7 @@ import type Sheet from '@theatre/core/sheets/Sheet'
 import type {ISheet} from '@theatre/core/sheets/TheatreSheet'
 import type {UnknownShorthandCompoundProps} from './propTypes/internals'
 import type {$IntentionalAny} from '@theatre/shared/utils/types'
+import type {IRafDriver, RafDriverPrivateAPI} from './rafDrivers'
 
 const publicAPIToPrivateAPIMap = new WeakMap()
 
@@ -24,6 +25,8 @@ export function privateAPI<P extends {type: string}>(
   ? SheetObject
   : P extends ISequence
   ? Sequence
+  : P extends IRafDriver
+  ? RafDriverPrivateAPI
   : never {
   return publicAPIToPrivateAPIMap.get(pub)
 }
@@ -35,6 +38,7 @@ export function privateAPI<P extends {type: string}>(
 export function setPrivateAPI(pub: IProject, priv: Project): void
 export function setPrivateAPI(pub: ISheet, priv: Sheet): void
 export function setPrivateAPI(pub: ISequence, priv: Sequence): void
+export function setPrivateAPI(pub: IRafDriver, priv: RafDriverPrivateAPI): void
 export function setPrivateAPI<Props extends UnknownShorthandCompoundProps>(
   pub: ISheetObject<Props>,
   priv: SheetObject,

--- a/theatre/core/src/rafDrivers.ts
+++ b/theatre/core/src/rafDrivers.ts
@@ -30,7 +30,14 @@ export function createRafDriver(conf?: {
     ticker.tick(time)
   }
 
-  const ticker = new Ticker()
+  const ticker = new Ticker({
+    onActive() {
+      conf?.start?.()
+    },
+    onDormant() {
+      conf?.stop?.()
+    },
+  })
 
   const driverPublicApi: IRafDriver = {
     tick,
@@ -48,10 +55,6 @@ export function createRafDriver(conf?: {
   }
 
   setPrivateAPI(driverPublicApi, driverPrivateApi)
-
-  // for now, we'll always call start as soon as the driver is created. Later we can
-  // call start if ticker actually has events queued, and stop if it doesn't.
-  driverPrivateApi.start?.()
 
   return driverPublicApi
 }

--- a/theatre/core/src/rafDrivers.ts
+++ b/theatre/core/src/rafDrivers.ts
@@ -1,0 +1,49 @@
+import {Ticker} from '@theatre/dataverse'
+import {setPrivateAPI} from './privateAPIs'
+
+export interface IRafDriver {
+  /**
+   * All raf derivers have have `driver.type === 'Theatre_RafDriver_PublicAPI'`
+   */
+  readonly type: 'Theatre_RafDriver_PublicAPI'
+  name: string
+  id: number
+  tick: (time: number) => void
+}
+
+export interface RafDriverPrivateAPI {
+  readonly type: 'Theatre_RafDriver_PrivateAPI'
+  publicApi: IRafDriver
+  ticker: Ticker
+  start?: () => void
+  stop?: () => void
+}
+
+let lastDriverId = 0
+
+export function createRafDriver(conf?: {
+  name?: string
+  start?: () => void
+  stop?: () => void
+}): {tick: (time: number) => void; name: string; id: number} {
+  const tick = (time: number): void => {}
+
+  const ticker = new Ticker()
+
+  const driverPublicApi: IRafDriver = {
+    tick,
+    id: lastDriverId++,
+    name: conf?.name ?? `CustomRafDriver-${lastDriverId}`,
+    type: 'Theatre_RafDriver_PublicAPI',
+  }
+
+  const driverPrivateApi: RafDriverPrivateAPI = {
+    type: 'Theatre_RafDriver_PrivateAPI',
+    publicApi: driverPublicApi,
+    ticker,
+  }
+
+  setPrivateAPI(driverPublicApi, driverPrivateApi)
+
+  return driverPublicApi
+}

--- a/theatre/core/src/rafDrivers.ts
+++ b/theatre/core/src/rafDrivers.ts
@@ -25,8 +25,10 @@ export function createRafDriver(conf?: {
   name?: string
   start?: () => void
   stop?: () => void
-}): {tick: (time: number) => void; name: string; id: number} {
-  const tick = (time: number): void => {}
+}): IRafDriver {
+  const tick = (time: number): void => {
+    ticker.tick(time)
+  }
 
   const ticker = new Ticker()
 
@@ -41,9 +43,15 @@ export function createRafDriver(conf?: {
     type: 'Theatre_RafDriver_PrivateAPI',
     publicApi: driverPublicApi,
     ticker,
+    start: conf?.start,
+    stop: conf?.stop,
   }
 
   setPrivateAPI(driverPublicApi, driverPrivateApi)
+
+  // for now, we'll always call start as soon as the driver is created. Later we can
+  // call start if ticker actually has events queued, and stop if it doesn't.
+  driverPrivateApi.start?.()
 
   return driverPublicApi
 }

--- a/theatre/core/src/sequences/TheatreSequence.ts
+++ b/theatre/core/src/sequences/TheatreSequence.ts
@@ -6,6 +6,7 @@ import AudioPlaybackController from './playbackControllers/AudioPlaybackControll
 import {getCoreTicker} from '@theatre/core/coreTicker'
 import type {Pointer} from '@theatre/dataverse'
 import {notify} from '@theatre/shared/notify'
+import type {IRafDriver} from '@theatre/core/rafDrivers'
 
 interface IAttachAudioArgs {
   /**
@@ -76,6 +77,12 @@ export interface ISequence {
      * The direction of the playback. Similar to CSS's animation-direction
      */
     direction?: IPlaybackDirection
+
+    /**
+     * Optionally provide a RAF driver to use for the playback. It'll default to
+     * the core driver if not provided, which is a `requestAnimationFrame()` driver.
+     */
+    rafDriver?: IRafDriver
   }): Promise<boolean>
 
   /**
@@ -233,11 +240,15 @@ export default class TheatreSequence implements ISequence {
       range: IPlaybackRange
       rate: number
       direction: IPlaybackDirection
+      rafDriver: IRafDriver
     }>,
   ): Promise<boolean> {
     const priv = privateAPI(this)
     if (priv._project.isReady()) {
-      return priv.play(conf)
+      const ticker = conf?.rafDriver
+        ? privateAPI(conf.rafDriver).ticker
+        : getCoreTicker()
+      return priv.play(conf ?? {}, ticker)
     } else {
       if (process.env.NODE_ENV !== 'production') {
         notify.warning(
@@ -289,7 +300,6 @@ export default class TheatreSequence implements ISequence {
       await resolveAudioBuffer(args)
 
     const playbackController = new AudioPlaybackController(
-      getCoreTicker(),
       decodedBuffer,
       audioContext,
       gainNode,

--- a/theatre/core/src/sequences/playbackControllers/DefaultPlaybackController.ts
+++ b/theatre/core/src/sequences/playbackControllers/DefaultPlaybackController.ts
@@ -23,6 +23,7 @@ export interface IPlaybackController {
     range: IPlaybackRange,
     rate: number,
     direction: IPlaybackDirection,
+    ticker: Ticker,
   ): Promise<boolean>
 
   /**
@@ -36,7 +37,10 @@ export interface IPlaybackController {
    * @returns  a promise that gets rejected if the playback stopped for whatever reason
    *
    */
-  playDynamicRange(rangeD: Prism<IPlaybackRange>): Promise<unknown>
+  playDynamicRange(
+    rangeD: Prism<IPlaybackRange>,
+    ticker: Ticker,
+  ): Promise<unknown>
 
   pause(): void
 }
@@ -49,7 +53,7 @@ export default class DefaultPlaybackController implements IPlaybackController {
   })
   readonly statePointer: Pointer<IPlaybackState>
 
-  constructor(private readonly _ticker: Ticker) {
+  constructor() {
     this.statePointer = this._state.pointer
   }
 
@@ -86,6 +90,7 @@ export default class DefaultPlaybackController implements IPlaybackController {
     range: IPlaybackRange,
     rate: number,
     direction: IPlaybackDirection,
+    ticker: Ticker,
   ): Promise<boolean> {
     if (this.playing) {
       this.pause()
@@ -93,7 +98,6 @@ export default class DefaultPlaybackController implements IPlaybackController {
 
     this.playing = true
 
-    const ticker = this._ticker
     const iterationLength = range[1] - range[0]
 
     {
@@ -203,14 +207,15 @@ export default class DefaultPlaybackController implements IPlaybackController {
     return deferred.promise
   }
 
-  playDynamicRange(rangeD: Prism<IPlaybackRange>): Promise<unknown> {
+  playDynamicRange(
+    rangeD: Prism<IPlaybackRange>,
+    ticker: Ticker,
+  ): Promise<unknown> {
     if (this.playing) {
       this.pause()
     }
 
     this.playing = true
-
-    const ticker = this._ticker
 
     const deferred = defer<boolean>()
 

--- a/theatre/studio/src/Studio.ts
+++ b/theatre/studio/src/Studio.ts
@@ -174,18 +174,22 @@ export class Studio {
       storeOpts.usePersistentStorage = false
     }
 
-    if (opts?.rafDriver) {
-      if (opts.rafDriver.type !== 'Theatre_RafDriver_PublicAPI') {
+    if (opts?.__experimental_rafDriver) {
+      if (
+        opts.__experimental_rafDriver.type !== 'Theatre_RafDriver_PublicAPI'
+      ) {
         throw new Error(
-          'parameter `rafDriver` in `studio.initialize({rafDriver})` must be either be undefined, or the return type of core.createRafDriver()',
+          'parameter `rafDriver` in `studio.initialize({__experimental_rafDriver})` must be either be undefined, or the return type of core.createRafDriver()',
         )
       }
 
-      const rafDriverPrivateApi = this._coreBits.privateAPI(opts.rafDriver)
+      const rafDriverPrivateApi = this._coreBits.privateAPI(
+        opts.__experimental_rafDriver,
+      )
       if (!rafDriverPrivateApi) {
         // TODO - need to educate the user about this edge case
         throw new Error(
-          'parameter `rafDriver` in `studio.initialize({rafDriver})` seems to come from a different version of `@theatre/core` than the version that is attached to `@theatre/studio`',
+          'parameter `rafDriver` in `studio.initialize({__experimental_rafDriver})` seems to come from a different version of `@theatre/core` than the version that is attached to `@theatre/studio`',
         )
       }
       this._rafDriver = rafDriverPrivateApi

--- a/theatre/studio/src/TheatreStudio.ts
+++ b/theatre/studio/src/TheatreStudio.ts
@@ -1,5 +1,4 @@
-import type {IProject, ISheet, ISheetObject} from '@theatre/core'
-import studioTicker from '@theatre/studio/studioTicker'
+import type {IProject, IRafDriver, ISheet, ISheetObject} from '@theatre/core'
 import type {Prism, Pointer} from '@theatre/dataverse'
 import {prism} from '@theatre/dataverse'
 import SimpleCache from '@theatre/shared/utils/SimpleCache'
@@ -173,6 +172,8 @@ export interface _StudioInitializeOpts {
    * Default: true
    */
   usePersistentStorage?: boolean
+
+  rafDriver?: IRafDriver | undefined
 }
 
 /**
@@ -440,7 +441,9 @@ export default class TheatreStudio implements IStudio {
   }
 
   onSelectionChange(fn: (s: (ISheetObject | ISheet)[]) => void): VoidFn {
-    return this._getSelectionPrism().onChange(studioTicker, fn, true)
+    const studio = getStudio()
+
+    return this._getSelectionPrism().onChange(studio.ticker, fn, true)
   }
 
   get selection(): Array<ISheetObject | ISheet> {

--- a/theatre/studio/src/TheatreStudio.ts
+++ b/theatre/studio/src/TheatreStudio.ts
@@ -173,7 +173,7 @@ export interface _StudioInitializeOpts {
    */
   usePersistentStorage?: boolean
 
-  rafDriver?: IRafDriver | undefined
+  __experimental_rafDriver?: IRafDriver | undefined
 }
 
 /**

--- a/theatre/studio/src/UIRoot/useKeyboardShortcuts.ts
+++ b/theatre/studio/src/UIRoot/useKeyboardShortcuts.ts
@@ -110,6 +110,7 @@ export default function useKeyboardShortcuts() {
 
             const playbackPromise = seq.playDynamicRange(
               prism(() => val(controlledPlaybackStateD).range),
+              getStudio().ticker,
             )
 
             const playbackStateBox = getPlaybackStateBox(seq)

--- a/theatre/studio/src/panels/SequenceEditorPanel/FrameGrid/FrameGrid.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/FrameGrid/FrameGrid.tsx
@@ -5,7 +5,7 @@ import {prism, val} from '@theatre/dataverse'
 import React, {useLayoutEffect, useMemo, useRef, useState} from 'react'
 import styled from 'styled-components'
 import createGrid from './createGrid'
-import studioTicker from '@theatre/studio/studioTicker'
+import getStudio from '@theatre/studio/getStudio'
 
 const Container = styled.div`
   position: absolute;
@@ -76,7 +76,7 @@ const FrameGrid: React.FC<{
         snapToGrid: (n: number) => sequence.closestGridPosition(n),
       }
     }).onChange(
-      studioTicker,
+      getStudio().ticker,
       (p) => {
         ctx.save()
         ctx.scale(ratio!, ratio!)

--- a/theatre/studio/src/panels/SequenceEditorPanel/FrameGrid/StampsGrid.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/FrameGrid/StampsGrid.tsx
@@ -6,7 +6,7 @@ import {darken} from 'polished'
 import React, {useLayoutEffect, useRef, useState} from 'react'
 import styled from 'styled-components'
 import createGrid from './createGrid'
-import studioTicker from '@theatre/studio/studioTicker'
+import getStudio from '@theatre/studio/getStudio'
 
 const Container = styled.div`
   position: absolute;
@@ -86,7 +86,7 @@ const StampsGrid: React.FC<{
         sequencePositionFormatter: sequence.positionFormatter,
         snapToGrid: (n: number) => sequence.closestGridPosition(n),
       }
-    }).onChange(studioTicker, drawStamps, true)
+    }).onChange(getStudio().ticker, drawStamps, true)
   }, [fullSecondStampsContainer, width, layoutP])
 
   return (

--- a/theatre/studio/src/studioTicker.ts
+++ b/theatre/studio/src/studioTicker.ts
@@ -1,5 +1,0 @@
-import {Ticker} from '@theatre/dataverse'
-
-const studioTicker = Ticker.raf
-
-export default studioTicker


### PR DESCRIPTION
This PR allows you to control when computations in Theatre tick forward.

We call this mechanism a `rafDriver` (raf stands for [`requestAnimationFrame`](https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame)).

The default `rafDriver` in Theatre creates a `raf` loop and ticks forward on each frame. With this PR, you can create your own `rafDriver`, which enables the following use-cases:

1. When using Theatre.js alongside other animation libs (`@react-three/fiber`/`gsap`/`lenis`/`etc`), you'd want all animation libs to use a single `raf` loop to keep the libraries in sync and also to get better performance.
2. In XR sessions, you'd want Theatre to tick forward using [`xr.requestAnimationFrame()`](https://developer.mozilla.org/en-US/docs/Web/API/XRSession/requestAnimationFrame).
3. In some advanced cases, you'd just want to manually tick forward (many ticks per frame, or skipping many frames, etc). This is useful for recording an animation, rendering to a file, testing an animation, running benchmarks, etc.

This PR resolves #39, replaces #230, and #88.

Here is how you'd create a custom `rafDriver`:

```js
import {createRafDriver} from '@theatre/core'

const rafDriver = createRafDriver({name: 'a custom 5fps raf driver'})

setInterval(() => {
  rafDriver.tick(performance.now())
}, 200)
```

Now, any time you set up an `onChange()` listener, pass your custom `rafDriver`:

```js
import {onChange} from '@theatre/core'

onChange(
  // let's say object is a Theatre object, the one returned from calling `sheet.object()`
  object.props,
  // this callback will now only be called at 5fps (and won't be called if there are no new values)
  // even if `sequence.play()` updates `object.props` at 60fps, this listener is called a maximum of 5fps
  (propValues) => {console.log(propValues)},
  rafDriver
)

// this will update the values of `object.props` at 60fps, but the listener above will still get called a maximum of 5fps
sheet.sequence.play()

// we can also customize at what resolution the sequence's playhead moves forward
sheet.sequence.play({rafDriver}) // the playhead will move forward at 5fps
```

You can optionally make studio use this `rafDriver`. This means the parts of the studio that tick based on raf, will now tick at 5fps. This is only useful if you're doing something crazy like running the studio (and not the core) in an XR frame.

```js
studio.initialize({
  __experimental_rafDriver: rafDriver,
})
```

`rafDriver`s can optionally provide a `start/stop` callback. Theatre will call `start()` when it actually has computations scheduled, and will call `stop` if there is nothing to update after a few ticks:

```js
import {createRafDriver} from '@theatre/core'
import type {IRafDriver} from '@theare/core'

function createBasicRafDriver(): IRafDriver {
  let rafId: number | null = null
  const start = (): void => {
    if (typeof window !== 'undefined') {
      const onAnimationFrame = (t: number) => {
        driver.tick(t)
        rafId = window.requestAnimationFrame(onAnimationFrame)
      }
      rafId = window.requestAnimationFrame(onAnimationFrame)
    } else {
      driver.tick(0)
      setTimeout(() => driver.tick(1), 0)
    }
  }

  const stop = (): void => {
    if (typeof window !== 'undefined') {
      if (rafId !== null) {
        window.cancelAnimationFrame(rafId)
      }
    } else {
      // nothing to do in SSR
    }
  }

  const driver = createRafDriver({name: 'DefaultCoreRafDriver', start, stop})

  return driver
}
```

A couple of design decisions:

1. You can have several `rafDriver`-s on the same page, or even listening to the changes in values of the same object. 
  
  ```js
  onChange(object.props, listener, aFiveFPSDriver)
  onChange(object.props, listener, a60FPSDriver)
  ```
  
2. I debated whether to allow setting a default `rafDriver` for a whole project or all of `@theatre/core`. That's certainly possible, and it would make the API less verbose. However, it also makes the API more ambiguous (like which driver takes precedence when there are several?) and more tricky (you'd have to call the hypothetical `core.setDefaultRafDriver()` before any computation is done).

3. We're not exposing `Ticker` because a `Ticker` has responsibilities beyond just scheduling, such as keeping a list of stale computations and (in the future) prioritizing them.