### PR TITLE
A temporary API for disabling play/pause via the space key

### DIFF
--- a/theatre/studio/src/TheatreStudio.ts
+++ b/theatre/studio/src/TheatreStudio.ts
@@ -435,9 +435,15 @@ export default class TheatreStudio implements IStudio {
 
   __experimental = {
     __experimental_disblePlayPauseKeyboardShortcut(): void {
+      // This is an experimental API to respond to this issue: https://discord.com/channels/870988717190426644/870988717190426647/1067906775602430062
+      // Ideally we need a coherent way for the user to control keyboard inputs, so we will remove this method in the future.
+      // Here is the procedure for removing it:
+      // 1. Replace this code with a `throw new Error("This is experimental method is now deprecated, and here is how to migrate: ...")`
+      // 2. Then keep it for a few months, and then remove it.
       __experimental_disblePlayPauseKeyboardShortcut()
     },
     __experimental_enablePlayPauseKeyboardShortcut(): void {
+      // see __experimental_disblePlayPauseKeyboardShortcut()
       __experimental_enablePlayPauseKeyboardShortcut()
     },
   }

--- a/theatre/studio/src/TheatreStudio.ts
+++ b/theatre/studio/src/TheatreStudio.ts
@@ -15,6 +15,10 @@ import getStudio from './getStudio'
 import {debounce} from 'lodash-es'
 import type Sheet from '@theatre/core/sheets/Sheet'
 import type {PaneInstanceId, ProjectId} from '@theatre/shared/utils/ids'
+import {
+  __experimental_disblePlayPauseKeyboardShortcut,
+  __experimental_enablePlayPauseKeyboardShortcut,
+} from './UIRoot/useKeyboardShortcuts'
 
 export interface ITransactionAPI {
   /**
@@ -390,6 +394,22 @@ export interface IStudio {
    * ```
    */
   createContentOfSaveFile(projectId: string): Record<string, unknown>
+
+  __experimental: {
+    /**
+     * Warning: This is an experimental API and will change in the future.
+     *
+     * Disables the play/pause keyboard shortcut (spacebar)
+     * Also see `__experimental_enablePlayPauseKeyboardShortcut()` to re-enable it.
+     */
+    __experimental_disblePlayPauseKeyboardShortcut(): void
+    /**
+     * Warning: This is an experimental API and will change in the future.
+     *
+     * Disables the play/pause keyboard shortcut (spacebar)
+     */
+    __experimental_enablePlayPauseKeyboardShortcut(): void
+  }
 }
 
 export default class TheatreStudio implements IStudio {
@@ -412,6 +432,15 @@ export default class TheatreStudio implements IStudio {
   }
 
   private readonly _cache = new SimpleCache()
+
+  __experimental = {
+    __experimental_disblePlayPauseKeyboardShortcut(): void {
+      __experimental_disblePlayPauseKeyboardShortcut()
+    },
+    __experimental_enablePlayPauseKeyboardShortcut(): void {
+      __experimental_enablePlayPauseKeyboardShortcut()
+    },
+  }
 
   /**
    * @internal

--- a/theatre/studio/src/UIRoot/useKeyboardShortcuts.ts
+++ b/theatre/studio/src/UIRoot/useKeyboardShortcuts.ts
@@ -9,6 +9,15 @@ import type {IPlaybackRange} from '@theatre/core/sequences/Sequence'
 import type Sequence from '@theatre/core/sequences/Sequence'
 import memoizeFn from '@theatre/shared/utils/memoizeFn'
 
+let playPauseKeyboardShortcutIsEnabled = true
+export function __experimental_disblePlayPauseKeyboardShortcut() {
+  playPauseKeyboardShortcutIsEnabled = false
+}
+
+export function __experimental_enablePlayPauseKeyboardShortcut() {
+  playPauseKeyboardShortcutIsEnabled = true
+}
+
 export default function useKeyboardShortcuts() {
   const studio = getStudio()
   useEffect(() => {
@@ -39,6 +48,7 @@ export default function useKeyboardShortcuts() {
         !e.altKey &&
         !e.ctrlKey
       ) {
+        if (!playPauseKeyboardShortcutIsEnabled) return
         // Control the playback using the `Space` key
         const seq = getSelectedSequence()
         if (seq) {


### PR DESCRIPTION
The API works like this:

```ts
// disabled playback via the spacebar key
studio.__experimental.__experimental_disblePlayPauseKeyboardShortcut()
// re-enables it
studio.__experimental.__experimental_enablePlayPauseKeyboardShortcut()
```

Use-case: https://discord.com/channels/870988717190426644/870988717190426647/1067906775602430062