### PR TITLE
Implement the experimental `createContentOfSaveFileTyped()`

### DIFF
--- a/theatre/core/src/index.ts
+++ b/theatre/core/src/index.ts
@@ -13,6 +13,18 @@ export type {UnknownShorthandCompoundProps} from './propTypes'
 import * as globalVariableNames from '@theatre/shared/globalVariableNames'
 import type StudioBundle from '@theatre/studio/StudioBundle'
 import CoreBundle from './CoreBundle'
+import type {OnDiskState} from './projects/store/storeTypes'
+
+/**
+ * NOTE: **INTERNAL and UNSTABLE** - This _WILL_ break between minor versions.
+ *
+ * This type represents the object returned by `studio.createContnentOfSaveFile()`. It's
+ * meant for advanced users who want to interact with the state of projects. In the vast
+ * majority of cases, you __should not__ use this type. Either an API for your use-case
+ * already exists, or you should open an issue on GitHub: https://github.com/theatre-js/theatre/issues
+ *
+ */
+export type __UNSTABLE_Project_OnDiskState = OnDiskState
 
 registerCoreBundle()
 

--- a/theatre/studio/src/TheatreStudio.ts
+++ b/theatre/studio/src/TheatreStudio.ts
@@ -21,6 +21,7 @@ import {
 } from './UIRoot/useKeyboardShortcuts'
 import type TheatreSheetObject from '@theatre/core/sheetObjects/TheatreSheetObject'
 import type TheatreSheet from '@theatre/core/sheets/TheatreSheet'
+import type {OnDiskState} from '@theatre/core/projects/store/storeTypes'
 
 export interface ITransactionAPI {
   /**
@@ -410,7 +411,7 @@ export interface IStudio {
    * })
    * ```
    */
-  createContentOfSaveFile(projectId: string): Record<string, unknown>
+  createContentOfSaveFile(projectId: string): OnDiskState
 
   __experimental: {
     /**
@@ -619,9 +620,7 @@ export default class TheatreStudio implements IStudio {
     return getStudio().paneManager.destroyPane(paneId as PaneInstanceId)
   }
 
-  createContentOfSaveFile(projectId: string): Record<string, unknown> {
-    return getStudio().createContentOfSaveFile(
-      projectId as ProjectId,
-    ) as $IntentionalAny
+  createContentOfSaveFile(projectId: string): OnDiskState {
+    return getStudio().createContentOfSaveFile(projectId as ProjectId)
   }
 }

--- a/theatre/studio/src/TheatreStudio.ts
+++ b/theatre/studio/src/TheatreStudio.ts
@@ -21,7 +21,7 @@ import {
 } from './UIRoot/useKeyboardShortcuts'
 import type TheatreSheetObject from '@theatre/core/sheetObjects/TheatreSheetObject'
 import type TheatreSheet from '@theatre/core/sheets/TheatreSheet'
-import type {OnDiskState} from '@theatre/core/projects/store/storeTypes'
+import type {__UNSTABLE_Project_OnDiskState} from '@theatre/core'
 
 export interface ITransactionAPI {
   /**
@@ -411,7 +411,7 @@ export interface IStudio {
    * })
    * ```
    */
-  createContentOfSaveFile(projectId: string): OnDiskState
+  createContentOfSaveFile(projectId: string): Record<string, unknown>
 
   __experimental: {
     /**
@@ -435,6 +435,18 @@ export interface IStudio {
      * @param persistenceKey - same persistencyKey as in `studio.initialize(opts)`, if any
      */
     __experimental_clearPersistentStorage(persistenceKey?: string): void
+
+    /**
+     * Warning: This is an experimental API and will change in the future.
+     *
+     * This is functionally the same as `studio.createContentOfSaveFile()`, but
+     * returns a typed object instead of a JSON object.
+     *
+     * See {@link __UNSTABLE_Project_OnDiskState} for more information.
+     */
+    __experimental_createContentOfSaveFileTyped(
+      projectId: string,
+    ): __UNSTABLE_Project_OnDiskState
   }
 }
 
@@ -474,6 +486,11 @@ export default class TheatreStudio implements IStudio {
     },
     __experimental_clearPersistentStorage(persistenceKey?: string): void {
       return getStudio().clearPersistentStorage(persistenceKey)
+    },
+    __experimental_createContentOfSaveFileTyped(
+      projectId: string,
+    ): __UNSTABLE_Project_OnDiskState {
+      return getStudio().createContentOfSaveFile(projectId) as $IntentionalAny
     },
   }
 
@@ -620,7 +637,9 @@ export default class TheatreStudio implements IStudio {
     return getStudio().paneManager.destroyPane(paneId as PaneInstanceId)
   }
 
-  createContentOfSaveFile(projectId: string): OnDiskState {
-    return getStudio().createContentOfSaveFile(projectId as ProjectId)
+  createContentOfSaveFile(projectId: string): Record<string, unknown> {
+    return getStudio().createContentOfSaveFile(
+      projectId as ProjectId,
+    ) as $IntentionalAny
   }
 }


### PR DESCRIPTION
Addresses #330 to fix the type for `createContentOfSaveFile` to use `OnDiskState` instead of `Record<string, unknown>` and `$IntentionalAny`.