### PR TITLE
Experimental API for forgetting objects/sheet

### DIFF
--- a/theatre/studio/src/store/stateEditors.ts
+++ b/theatre/studio/src/store/stateEditors.ts
@@ -622,6 +622,29 @@ namespace stateEditors {
           return sheetsById[p.sheetId]!
         }
 
+        export function forgetObject(
+          p: WithoutSheetInstance<SheetObjectAddress>,
+        ) {
+          const sheetState =
+            drafts().historic.coreByProject[p.projectId].sheetsById[p.sheetId]
+          if (!sheetState) return
+          delete sheetState.staticOverrides.byObject[p.objectKey]
+
+          const sequence = sheetState.sequence
+          if (!sequence) return
+          delete sequence.tracksByObject[p.objectKey]
+        }
+
+        export function forgetSheet(p: WithoutSheetInstance<SheetAddress>) {
+          const sheetState =
+            drafts().historic.coreByProject[p.projectId].sheetsById[p.sheetId]
+          if (sheetState) {
+            delete drafts().historic.coreByProject[p.projectId].sheetsById[
+              p.sheetId
+            ]
+          }
+        }
+
         export namespace sequence {
           export function _ensure(
             p: WithoutSheetInstance<SheetAddress>,


### PR DESCRIPTION
This adds two methods to the `transactionAPI` that would remove an object or sheet's state from the project's state.

```ts
import {getProject} from '@theatre/core'
import studio from '@theare/studio'

const project = getProject('...')
const sheet = project.sheet('...')
const object = sheet.object('...')

// let's say you've already set up prop values for your object and created a sequence in the studio

studio.transaction((api) => {
  // calling this will make it as if you never set values for this object or put it in a sequence
  api.__experimental_forgetObject(object)
  
  // calling this will make it as if you never set values for _any_ object in this sheet, and you never created a sequence either.
  api.__experimental_forgetSheet(sheet)

  // note that if you're calling __experimental_forgetSheet(), then there is no need to call __experimental_forgetObject() in case that object belongs in that sheet.
})

// now if you export the project's state, or do that programmatically, the sheet/object won't be in the exported state:
studio.
createContentOfSaveFile(project.address.projectId) // won't have the sheet/object in it

// note that cmd/ctrl+z will still undo the above operations
```

