### PR TITLE
optimize builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,4 +116,4 @@ jobs:
           yarn workspace @theatre/compatibility-tests run install-fixtures
           --verbose
       # after that, we run the jest tests for each fixture
-      - run: yarn test:compat
+      - run: yarn test:compat:run

--- a/compatibility-tests/README.md
+++ b/compatibility-tests/README.md
@@ -14,7 +14,7 @@ This setup helps us test whether Theatre.js is compatible with popular tools in 
 
 1. First, we run `yarn run install-fixtures`, which tries to install Theatre.js on a fixture as if `@theatre/core|studio|r3f` were installed through npm. This script runs a [local npm registry](https://github.com/verdaccio/verdaccio) and publishes a production build of all the Theatre.js packages to it. Then, it iterates through `./fixtures/*/package` and runs `$ npm install` on them, using that local npm registry. 
   **If this step fails**, that usually means one of `@theatre/*` packages has a `dependency/peerDependency` that cannot be satisfied by `npm/yarn`. So this is always the first thing to fix.
-1. Then, we run `$ yarn test:compat`, which will run jest on all of `*.compat-test.ts` files, each of which tests an aspect of a test setup.
+1. Then, we run `$ yarn test:compat:run`, which will run jest on all of `*.compat-test.ts` files, each of which tests an aspect of a test setup.
 2. Most of our fixtures don't actually have `.compat-test.ts` files, so we'll have to run them manually and see if Theatre still works in them, jut like a manual QA pass.
 
 > **Gotchas**

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "clean": "zx scripts/clean.mjs",
     "build:ts": "tsc --build ./devEnv/typecheck-all-projects/tsconfig.all.json",
     "test": "jest",
-    "test:compat": "jest --config jest.compat-tests.config.js",
+    "test:compat:install": "yarn workspace @theatre/compatibility-tests run install-fixtures",
+    "test:compat:run": "jest --config jest.compat-tests.config.js",
     "postinstall": "husky install",
     "release": "zx scripts/release.mjs",
     "lint:all": "eslint . --ext ts,tsx --ignore-path=.gitignore --rulesdir ./devEnv/eslint/rules"

--- a/theatre/devEnv/createBundles.ts
+++ b/theatre/devEnv/createBundles.ts
@@ -46,6 +46,11 @@ export function createBundles(watch: boolean) {
       esbuildConfig.mainFields = ['browser', 'module', 'main']
       esbuildConfig.target = ['firefox57', 'chrome58']
       esbuildConfig.conditions = ['browser', 'node']
+    } else {
+      esbuildConfig.define!['process.env.NODE_ENV'] =
+        JSON.stringify('production')
+
+      esbuildConfig.minify = true
     }
 
     build({


### PR DESCRIPTION
We used to let the user's bundler config determine if the studio should be optimized for production. This only happened if the user set `process.env.NODE_ENV === "production"` and turned on tree-shaking.

Since most users run studio in a dev server, they won't see any benefits from these optimizations. This change enables these optimizations for `@theatre/studio`. However, `@theatre/core` still depends on the user's bundler config.