### PR TITLE
playground needs yarn build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,7 @@ The quickest way to start tweaking things is to run the `playground` package.
 ```sh
 $ cd ./packages/playground
 $ yarn serve
+$ yarn build
 # or, shortcut:
 $ cd root
 $ yarn playground


### PR DESCRIPTION
I followed the contributing doc to run theatre locally. The playground would not run without yarn build. After a fresh clone and `yarn` I did this:

```bash
$ cd ./packages/playground
$ yarn serve
Rejected "writing build index.html":
    Error: ENOENT: no such file or directory, open 'theatre/packages/playground/build/index.html'
$ yarn build
$ yarn serve
Playground running at http://localhost:8080
```