### PR TITLE
"File Prop" Type

### DIFF
--- a/packages/playground/src/shared/file/index.html
+++ b/packages/playground/src/shared/file/index.html
@@ -1,0 +1,11 @@
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Theatre.js Playground</title>
+    <script src="./index.tsx" type="module"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/packages/playground/src/shared/file/index.tsx
+++ b/packages/playground/src/shared/file/index.tsx
@@ -1,0 +1,52 @@
+import {getProject, types} from '@theatre/core'
+import studio from '@theatre/studio'
+import React, {useEffect, useState} from 'react'
+import ReactDom from 'react-dom/client'
+import styled from 'styled-components'
+
+const project = getProject('Image type playground', {
+  assets: {
+    baseUrl: '/',
+  },
+})
+studio.initialize()
+const sheet = project.sheet('Image type')
+
+const Wrapper = styled.div`
+  position: absolute;
+  inset: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`
+
+const FileTypeExample: React.FC<{}> = (props) => {
+  const [fileUrl, setFileUrl] = useState<string>()
+
+  useEffect(() => {
+    const object = sheet.object('File holder', {
+      f: types.file('', {
+        label: 'The OBJ',
+      }),
+    })
+    object.onValuesChange(({f}) => {
+      setFileUrl(project.getAssetUrl(f))
+    })
+
+    return () => {
+      sheet.detachObject('canvas')
+    }
+  }, [])
+
+  return <Wrapper>File url is: {fileUrl}</Wrapper>
+}
+
+project.ready
+  .then(() => {
+    ReactDom.createRoot(document.getElementById('root')!).render(
+      <FileTypeExample />,
+    )
+  })
+  .catch((err) => {
+    console.error(err)
+  })

--- a/packages/playground/src/shared/image/index.tsx
+++ b/packages/playground/src/shared/image/index.tsx
@@ -1,7 +1,3 @@
-/**
- * A super basic Turtle geometry renderer hooked up to Theatre, so the parameters
- * can be tweaked and animated.
- */
 import {getProject, types} from '@theatre/core'
 import studio from '@theatre/studio'
 import React, {useEffect, useState} from 'react'

--- a/packages/theatric/src/index.ts
+++ b/packages/theatric/src/index.ts
@@ -59,7 +59,7 @@ export function initialize(config: IProjectConfig): Promise<void> {
 }
 
 export function getAssetUrl(asset: {
-  type: 'image'
+  type: 'image' | 'file'
   id: string | undefined
 }): string | undefined {
   if (!_project) {

--- a/theatre/core/src/projects/TheatreProject.ts
+++ b/theatre/core/src/projects/TheatreProject.ts
@@ -3,7 +3,7 @@ import Project from '@theatre/core/projects/Project'
 import type {ISheet} from '@theatre/core/sheets/TheatreSheet'
 
 import type {ProjectAddress} from '@theatre/shared/utils/addresses'
-import type {Asset} from '@theatre/shared/utils/assets'
+import type {Asset, File} from '@theatre/shared/utils/assets'
 import type {
   ProjectId,
   SheetId,
@@ -80,7 +80,7 @@ export interface IProject {
    * @param asset - The asset to get the URL for
    * @returns The URL for the asset, or `undefined` if the asset is not found
    */
-  getAssetUrl(asset: Asset): string | undefined
+  getAssetUrl(asset: Asset | File): string | undefined
 }
 
 export default class TheatreProject implements IProject {

--- a/theatre/core/src/propTypes/index.ts
+++ b/theatre/core/src/propTypes/index.ts
@@ -17,7 +17,7 @@ import type {
 import {propTypeSymbol, sanitizeCompoundProps} from './internals'
 // eslint-disable-next-line unused-imports/no-unused-imports
 import type SheetObject from '@theatre/core/sheetObjects/SheetObject'
-import type {Asset} from '@theatre/shared/utils/assets'
+import type {Asset, File} from '@theatre/shared/utils/assets'
 
 // Notes on naming:
 // As of now, prop types are either `simple` or `composite`.
@@ -136,6 +136,74 @@ export const compound = <Props extends UnknownShorthandCompoundProps>(
     },
   }
   return config
+}
+
+/**
+ * A file prop type
+ *
+ * @example
+ * Usage:
+ * ```ts
+ *
+ * // with a label:
+ * const obj = sheet.object('key', {
+ *   url: t.file('My file.glb', {
+ *     label: 'Model'
+ *   })
+ * })
+ * ```
+ *
+ * @param opts - Options (See usage examples)
+ */
+export const file = (
+  // The defaultValue parameter is a string for convenience, but it will be converted to an Asset object
+  defaultValue: File['id'],
+  opts: {
+    label?: string
+    interpolate?: Interpolator<File['id']>
+  } = {},
+): PropTypeConfig_File => {
+  if (process.env.NODE_ENV !== 'production') {
+    validateCommonOpts('t.file(defaultValue, opts)', opts)
+  }
+
+  const interpolate: Interpolator<File> = (left, right, progression) => {
+    const stringInterpolate = opts.interpolate ?? leftInterpolate
+
+    return {
+      type: 'file',
+      id: stringInterpolate(left.id, right.id, progression),
+    }
+  }
+
+  return {
+    type: 'file',
+    default: {type: 'file', id: defaultValue},
+    valueType: null as $IntentionalAny,
+    [propTypeSymbol]: 'TheatrePropType',
+    label: opts.label,
+    interpolate,
+    deserializeAndSanitize: _ensureFile,
+  }
+}
+
+const _ensureFile = (val: unknown): File | undefined => {
+  if (!val) return undefined
+
+  let valid = true
+
+  if (
+    typeof (val as $IntentionalAny).id !== 'string' &&
+    ![null, undefined].includes((val as $IntentionalAny).id)
+  ) {
+    valid = false
+  }
+
+  if ((val as $IntentionalAny).type !== 'file') valid = false
+
+  if (!valid) return undefined
+
+  return val as File
 }
 
 /**
@@ -778,6 +846,7 @@ export interface PropTypeConfig_StringLiteral<T extends string>
 export interface PropTypeConfig_Rgba extends ISimplePropType<'rgba', Rgba> {}
 
 export interface PropTypeConfig_Image extends ISimplePropType<'image', Asset> {}
+export interface PropTypeConfig_File extends ISimplePropType<'file', File> {}
 
 type DeepPartialCompound<Props extends UnknownValidCompoundProps> = {
   [K in keyof Props]?: DeepPartial<Props[K]>
@@ -812,6 +881,7 @@ export type PropTypeConfig_AllSimples =
   | PropTypeConfig_StringLiteral<$IntentionalAny>
   | PropTypeConfig_Rgba
   | PropTypeConfig_Image
+  | PropTypeConfig_File
 
 export type PropTypeConfig =
   | PropTypeConfig_AllSimples

--- a/theatre/shared/src/utils/assets.ts
+++ b/theatre/shared/src/utils/assets.ts
@@ -48,3 +48,4 @@ export function getAllPossibleAssetIDs(project: Project, type?: string) {
 }
 
 export type Asset = {type: 'image'; id: string | undefined}
+export type File = {type: 'file'; id: string | undefined}

--- a/theatre/studio/src/propEditors/simpleEditors/FilePropEditor.tsx
+++ b/theatre/studio/src/propEditors/simpleEditors/FilePropEditor.tsx
@@ -1,0 +1,154 @@
+import type {PropTypeConfig_File} from '@theatre/core/propTypes'
+import {Package, Trash} from '@theatre/studio/uiComponents/icons'
+import React, {useCallback, useEffect} from 'react'
+import styled, {css} from 'styled-components'
+import type {ISimplePropEditorReactProps} from './ISimplePropEditorReactProps'
+
+const Container = styled.div<{empty: boolean}>`
+  display: flex;
+  align-items: center;
+  height: 100%;
+  gap: 4px;
+`
+
+const AddFile = styled.div`
+  position: absolute;
+  inset: -5px;
+  // rotate 45deg
+  transform: rotate(45deg);
+  --checker-color: #ededed36;
+  &:hover {
+    --checker-color: #ededed77;
+  }
+  // checkerboard background with 4px squares
+  background-image: linear-gradient(
+      45deg,
+      var(--checker-color) 25%,
+      transparent 25%
+    ),
+    linear-gradient(-45deg, var(--checker-color) 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, var(--checker-color) 75%),
+    linear-gradient(-45deg, transparent 75%, var(--checker-color) 75%);
+  background-size: 5px 5px;
+`
+
+const InputLabel = styled.label<{empty: boolean}>`
+  position: relative;
+  cursor: default;
+  box-sizing: border-box;
+
+  height: 18px;
+  aspect-ratio: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 16px;
+
+  overflow: hidden;
+  color: #ccc;
+  &:hover {
+    color: white;
+  }
+
+  border-radius: 99999px;
+  border: 1px solid hwb(220deg 40% 52%);
+  &:hover {
+    border-color: hwb(220deg 45% 52%);
+  }
+
+  ${(props) => (props.empty ? css`` : css``)}
+`
+
+// file input
+const Input = styled.input.attrs({type: 'file'})`
+  display: none;
+`
+
+const DeleteButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  outline: none;
+  background: transparent;
+  color: #a8a8a9;
+
+  border: none;
+  height: 100%;
+  aspect-ratio: 1/1;
+
+  opacity: 0;
+
+  ${Container}:hover & {
+    opacity: 0.8;
+  }
+
+  &:hover {
+    opacity: 1;
+    color: white;
+  }
+`
+
+function FilePropEditor({
+  propConfig,
+  editingTools,
+  value,
+  autoFocus,
+}: ISimplePropEditorReactProps<PropTypeConfig_File>) {
+  const [previewUrl, setPreviewUrl] = React.useState<string>()
+
+  useEffect(() => {
+    if (value) {
+      setPreviewUrl(editingTools.getAssetUrl(value))
+    } else {
+      setPreviewUrl(undefined)
+    }
+  }, [value])
+
+  const onChange = useCallback(
+    async (event) => {
+      const file = event.target.files[0]
+      editingTools.permanentlySetValue({type: 'file', id: undefined})
+      const fileId = await editingTools.createAsset(file)
+
+      if (!fileId) {
+        editingTools.permanentlySetValue(value)
+      } else {
+        editingTools.permanentlySetValue({
+          type: 'file',
+          id: fileId,
+        })
+      }
+      event.target.value = null
+    },
+    [editingTools, value],
+  )
+
+  const empty = !value?.id
+
+  return (
+    <Container empty={empty}>
+      <InputLabel
+        empty={empty}
+        title={
+          empty ? 'Upload file' : `"${value.id}" (Click to upload new file)`
+        }
+      >
+        <Input type="file" onChange={onChange} autoFocus={autoFocus} />
+        {previewUrl ? <Package /> : <AddFile />}
+      </InputLabel>
+
+      {!empty && (
+        <DeleteButton
+          title="Delete file"
+          onClick={() => {
+            editingTools.permanentlySetValue({type: 'file', id: undefined})
+          }}
+        >
+          <Trash />
+        </DeleteButton>
+      )}
+    </Container>
+  )
+}
+
+export default FilePropEditor

--- a/theatre/studio/src/propEditors/simpleEditors/simplePropEditorByPropType.ts
+++ b/theatre/studio/src/propEditors/simpleEditors/simplePropEditorByPropType.ts
@@ -8,6 +8,7 @@ import RgbaPropEditor from './RgbaPropEditor'
 import type {ISimplePropEditorReactProps} from './ISimplePropEditorReactProps'
 import type {PropConfigForType} from '@theatre/studio/propEditors/utils/PropConfigForType'
 import ImagePropEditor from './ImagePropEditor'
+import FilePropEditor from './FilePropEditor'
 
 export const simplePropEditorByPropType: ISimplePropEditorByPropType = {
   number: NumberPropEditor,
@@ -16,6 +17,7 @@ export const simplePropEditorByPropType: ISimplePropEditorByPropType = {
   stringLiteral: StringLiteralPropEditor,
   rgba: RgbaPropEditor,
   image: ImagePropEditor,
+  file: FilePropEditor,
 }
 
 type ISimplePropEditorByPropType = {

--- a/theatre/studio/src/propEditors/useEditingToolsForSimpleProp.tsx
+++ b/theatre/studio/src/propEditors/useEditingToolsForSimpleProp.tsx
@@ -20,7 +20,7 @@ import type {NearbyKeyframes} from './getNearbyKeyframesOfTrack'
 import {getNearbyKeyframesOfTrack} from './getNearbyKeyframesOfTrack'
 import type {NearbyKeyframesControls} from './NextPrevKeyframeCursors'
 import NextPrevKeyframeCursors from './NextPrevKeyframeCursors'
-import type {Asset} from '@theatre/shared/utils/assets'
+import type {Asset, File as AssetFile} from '@theatre/shared/utils/assets'
 
 interface EditingToolsCommon<T> {
   value: T
@@ -33,7 +33,7 @@ interface EditingToolsCommon<T> {
   discardTemporaryValue(): void
   permanentlySetValue(v: T): void
 
-  getAssetUrl: (asset: Asset) => string | undefined
+  getAssetUrl: (asset: Asset | AssetFile) => string | undefined
   createAsset(asset: File): Promise<string | null>
 }
 
@@ -116,7 +116,7 @@ function createPrism<T extends SerializablePrimitive>(
     const editAssets = {
       createAsset: (asset: File): Promise<string | null> =>
         obj.sheet.project.assetStorage.createAsset(asset),
-      getAssetUrl: (asset: Asset) =>
+      getAssetUrl: (asset: Asset | AssetFile) =>
         asset.id
           ? obj.sheet.project.assetStorage.getAssetUrl(asset.id)
           : undefined,

--- a/theatre/studio/src/propEditors/utils/IEditingTools.tsx
+++ b/theatre/studio/src/propEditors/utils/IEditingTools.tsx
@@ -1,10 +1,10 @@
-import type {Asset} from '@theatre/shared/utils/assets'
+import type {Asset, File} from '@theatre/shared/utils/assets'
 
 export interface IEditingTools<T> {
   temporarilySetValue(v: T): void
   discardTemporaryValue(): void
   permanentlySetValue(v: T): void
 
-  getAssetUrl(asset: Asset): string | undefined
+  getAssetUrl(asset: Asset | File): string | undefined
   createAsset(asset: Blob): Promise<string | null>
 }


### PR DESCRIPTION
There is already an "Image" Prop Type but it is not possible to select other file types besides images. 

With this new "File" Prop Type, it will be possible to select any file type.

### Example use case:
Select *glb* file to change model.