### PR TITLE
fix(CurveEditor): error when copy/pasting eases

### DIFF
--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/KeyframeEditor/CurveEditorPopover/CurveEditorPopover.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/BasicKeyframedTrack/KeyframeEditor/CurveEditorPopover/CurveEditorPopover.tsx
@@ -173,7 +173,8 @@ const CurveEditorPopover: React.VFC<ICurveEditorPopoverProps> = (props) => {
     cssCubicBezierArgsFromHandles(easing),
   )
 
-  const onInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const onInputChange = (e?: React.ChangeEvent<HTMLInputElement>) => {
+    if (e === undefined) return
     setTextInputMode(TextInputMode.user)
     setInputValue(e.target.value)
 


### PR DESCRIPTION
Fixes the bug when a user copies the easing preset and tries pasting it somewhere else:

`Uncaught TypeError: Cannot read properties of undefined (reading 'target') at onInputChange (CurveEditorPopover.tsx:178:21)`