### PR TITLE
Feat/sharable sequence data

### DIFF
--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/DataViewer/components.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/DataViewer/components.tsx
@@ -1,0 +1,35 @@
+import styled from 'styled-components'
+
+export const DataViewerContainer = styled.div`
+  pointer-events: none;
+  position: absolute;
+  left: 10px;
+  top: 18px;
+  width: calc(var(--unitSpaceToScaledSpaceMultiplier) * 1px);
+  height: 100%;
+`
+
+export const SVGContainer = styled.svg`
+  margin: 0;
+`
+
+export const Polygon = styled.polygon`
+  fill: rgba(102, 102, 102, 0.25);
+  stroke: #666;
+  stroke-width: 1px;
+  vector-effect: non-scaling-stroke;
+`
+
+export const Rect = styled.rect`
+  fill: rgba(102, 102, 102, 0.25);
+  stroke: #666;
+  stroke-width: 1px;
+  vector-effect: non-scaling-stroke;
+`
+
+export const Circle = styled.circle`
+  r: 1;
+  fill: #ccc;
+  stroke: none;
+  vector-effect: non-scaling-stroke;
+`

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/DataViewer/index.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/DataViewer/index.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import {val} from '@theatre/dataverse'
+import type {Pointer} from '@theatre/dataverse'
+import getStudio from '@theatre/studio/getStudio'
+import type {SequenceEditorPanelLayout} from '@theatre/studio/panels/SequenceEditorPanel/layout/layout'
+import {DataViewerContainer, SVGContainer} from './components'
+import {generateSVGData, generateSVGTime} from './svg'
+
+// Component
+
+export const DataViewer: React.FC<{
+  layoutP: Pointer<SequenceEditorPanelLayout>
+}> = ({layoutP}) => {
+  const sheet = val(layoutP.sheet)
+  const sequence = sheet.getSequence()
+  const duration = sequence.length
+  const scale = val(layoutP.scaledSpace.fromUnitSpace)(1)
+  const dataW = scale * duration
+  const dataH = val(layoutP.rightDims.height) - 30
+  let svg = undefined
+
+  const dataSet =
+    getStudio().atomP.historic.projects.stateByProjectId[
+      sheet.address.projectId
+    ].stateBySheetId[sheet.address.sheetId].sequenceEditor.dataSet
+  const sequenceData = val(dataSet)
+  if (sequenceData !== undefined) {
+    if (sequenceData.data !== undefined && sequenceData.data.length > 0) {
+      if (sequenceData.type === 'Time') {
+        svg = generateSVGTime(sequenceData.data, scale, dataW, dataH)
+      } else {
+        svg = generateSVGData(sequenceData.data, scale, dataH)
+      }
+    }
+  }
+
+  return (
+    <DataViewerContainer
+      id="sequenceData"
+      style={{
+        width: `${dataW}px`,
+        height: `${dataH}px`,
+        top: `${val(layoutP.graphEditorDims.padding.top)}px`,
+      }}
+    >
+      <SVGContainer viewBox={`0 0 ${dataW} ${dataH}`}>{svg}</SVGContainer>
+    </DataViewerContainer>
+  )
+}

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/DataViewer/svg.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/DataViewer/svg.tsx
@@ -1,0 +1,62 @@
+import React from 'react'
+import {Circle, Polygon, Rect} from './components'
+import type {SequenceDataItem} from './types'
+
+/**
+ * A block of data
+ */
+export function generateSVGData(
+  data: SequenceDataItem[],
+  scale: number,
+  dataH: number,
+) {
+  return (
+    <g>
+      {data.map((item: SequenceDataItem) => {
+        const duration = item.duration !== undefined ? item.duration : 0
+        return (
+          <Rect
+            x={item.position * scale}
+            y={(1 - item.value) * dataH}
+            width={duration * scale}
+            height={item.value * dataH}
+            key={Math.random()}
+          />
+        )
+      })}
+    </g>
+  )
+}
+
+/**
+ * 1 point in time of data
+ */
+export function generateSVGTime(
+  data: SequenceDataItem[],
+  scale: number,
+  dataW: number,
+  dataH: number,
+) {
+  let pts = `0,${dataH}`
+  let ptData: Array<number[]> = []
+  for (let i = 0; i < data.length; i++) {
+    const x = Math.round(data[i].position * scale)
+    const y = Math.round((1 - data[i].value) * dataH)
+    pts += ` ${x},${y}`
+    ptData.push([x, y])
+  }
+  const lastPt = ptData[ptData.length - 1]
+  if (lastPt[1] > 0) {
+    pts += ` ${lastPt[0]},${dataH}`
+  }
+  return (
+    <>
+      <Polygon points={pts} />
+      <g>
+        {ptData.map((value: number[]) => {
+          return <Circle cx={value[0]} cy={value[1]} key={Math.random()} />
+        })}
+      </g>
+    </>
+  )
+}

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/DataViewer/types.ts
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/DataViewer/types.ts
@@ -1,0 +1,7 @@
+export type SequenceDataType = 'Data' | 'Time'
+
+export type SequenceDataItem = {
+  position: number
+  value: number
+  duration?: number
+}

--- a/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/Right.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/DopeSheet/Right/Right.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components'
 import DopeSheetSelectionView from './DopeSheetSelectionView'
 import HorizontallyScrollableArea from './HorizontallyScrollableArea'
 import SheetRow from './SheetRow'
+import {DataViewer} from './DataViewer'
 
 export const contentWidth = 1000000
 
@@ -36,6 +37,7 @@ const Right: React.FC<{
       <>
         <HorizontallyScrollableArea layoutP={layoutP} height={height}>
           <DopeSheetSelectionView layoutP={layoutP} height={height}>
+            <DataViewer layoutP={layoutP} />
             <ListContainer style={{top: tree.top + 'px'}}>
               <SheetRow leaf={tree} layoutP={layoutP} />
             </ListContainer>

--- a/theatre/studio/src/panels/SequenceEditorPanel/RightOverlay/Playhead.tsx
+++ b/theatre/studio/src/panels/SequenceEditorPanel/RightOverlay/Playhead.tsx
@@ -340,6 +340,72 @@ function usePlayheadContextMenu(
             })
           },
         },
+        {
+          label: 'Add Data',
+          callback: () => {
+            const prompStr = prompt('Sequence Data', '')
+            if (prompStr !== null && prompStr.length > 0) {
+              const value = JSON.parse(prompStr)
+              getStudio().transaction(({stateEditors}) => {
+                const sheet = val(options.layoutP.sheet)
+                const {sequenceEditor} =
+                  stateEditors.studio.historic.projects.stateByProjectId
+                    .stateBySheetId
+                // Data
+                if (value !== undefined) {
+                  sequenceEditor.setData({
+                    sheetAddress: sheet.address,
+                    dataSet: value,
+                  })
+                }
+              })
+            }
+          },
+        },
+        {
+          label: 'Import Sequence Data',
+          callback: () => {
+            const prompStr = prompt('Sequence Data', '')
+            if (prompStr !== null && prompStr.length > 0) {
+              const value = JSON.parse(prompStr)
+              getStudio().transaction(({stateEditors}) => {
+                const sheet = val(options.layoutP.sheet)
+                const sheetSequence = sheet.getSequence()
+                const {sequenceEditor} =
+                  stateEditors.studio.historic.projects.stateByProjectId
+                    .stateBySheetId
+
+                // Data
+                if (value.data !== undefined) {
+                  sequenceEditor.setData({
+                    sheetAddress: sheet.address,
+                    dataSet: value.data,
+                  })
+                }
+                // Markers
+                if (value.markers !== undefined) {
+                  sequenceEditor.replaceMarkers({
+                    sheetAddress: sheet.address,
+                    markers: value.markers,
+                    snappingFunction: sheetSequence.closestGridPosition,
+                  })
+                }
+              })
+            }
+          },
+        },
+        {
+          label: 'Export Sequence Data',
+          callback: () => {
+            getStudio().transaction(({stateEditors}) => {
+              const sheet = val(options.layoutP.sheet)
+              const {sequenceEditor} =
+                stateEditors.studio.historic.projects.stateByProjectId
+                  .stateBySheetId
+              sequenceEditor.exportSequenceEditor(sheet.address)
+            })
+          },
+        },
       ]
     },
   })

--- a/theatre/studio/src/store/types/historic.ts
+++ b/theatre/studio/src/store/types/historic.ts
@@ -21,6 +21,10 @@ import type {
   SheetInstanceId,
   UIPanelId,
 } from '@theatre/shared/utils/ids'
+import type {
+  SequenceDataItem,
+  SequenceDataType,
+} from '@theatre/studio/panels/SequenceEditorPanel/DopeSheet/Right/DataViewer/types'
 
 export type PanelPosition = {
   edges: {
@@ -89,12 +93,23 @@ export type StudioHistoricStateSequenceEditorMarker = {
 }
 
 /**
+ * Allows you to sync data to animation in your sequence.
+ *
+ * See root {@link StudioHistoricState}
+ */
+export type StudioHistoricStateSequenceEditorData = {
+  type?: SequenceDataType
+  data?: SequenceDataItem[]
+}
+
+/**
  * See parent {@link StudioHistoricStateProject}.
  * See root {@link StudioHistoricState}
  */
 export type StudioHistoricStateProjectSheet = {
   selectedInstanceId: undefined | SheetInstanceId
   sequenceEditor: {
+    dataSet?: StudioHistoricStateSequenceEditorData
     markerSet?: PointableSet<
       SequenceMarkerId,
       StudioHistoricStateSequenceEditorMarker


### PR DESCRIPTION
Replacing previous ticket: https://github.com/theatre-js/theatre/pull/422

Sheets can now import/export Markers and custom visual data.

@AriaMinaei There's still a few things I'd like to do with this:
1. Export project data sheet, similar to `Export Sample project to JSON`
2. Extend studio to load the data after `initialize`

Do you have time to help me with this?