### PR TITLE
Add failing Vite v4 compatibility test

### DIFF
--- a/compat-tests/fixtures/basic-vite4/basic-vite4.compat-test.ts
+++ b/compat-tests/fixtures/basic-vite4/basic-vite4.compat-test.ts
@@ -1,0 +1,40 @@
+// @cspotcode/zx is zx in CommonJS
+import {$, cd, path, ProcessPromise} from '@cspotcode/zx'
+import {testServerAndPage} from '../../utils/testUtils'
+
+const PATH_TO_PACKAGE = path.join(__dirname, `./package`)
+
+describe(`basic-vite4`, () => {
+  test(`\`$ vite build\` should succeed`, async () => {
+    cd(PATH_TO_PACKAGE)
+    const {exitCode} = await $`npm run build`
+    // at this point, the build should have succeeded
+    expect(exitCode).toEqual(0)
+  })
+
+  describe(`vite preview`, () => {
+    function startServerOnPort(port: number): ProcessPromise<unknown> {
+      cd(PATH_TO_PACKAGE)
+
+      return $`npm run preview -- --port ${port}`
+    }
+
+    testServerAndPage({
+      startServerOnPort,
+      checkServerStdoutToSeeIfItsReady: (chunk) => chunk.includes('--host'),
+    })
+  })
+
+  describe(`vite dev`, () => {
+    function startServerOnPort(port: number): ProcessPromise<unknown> {
+      cd(PATH_TO_PACKAGE)
+
+      return $`npm run dev -- --port ${port}`
+    }
+
+    testServerAndPage({
+      startServerOnPort,
+      checkServerStdoutToSeeIfItsReady: (chunk) => chunk.includes('--host'),
+    })
+  })
+})

--- a/compat-tests/fixtures/basic-vite4/package/.gitignore
+++ b/compat-tests/fixtures/basic-vite4/package/.gitignore
@@ -1,0 +1,3 @@
+/.cache
+/dist
+/package-lock.json

--- a/compat-tests/fixtures/basic-vite4/package/index.html
+++ b/compat-tests/fixtures/basic-vite4/package/index.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<script type="module" src="./src/index.ts"></script>

--- a/compat-tests/fixtures/basic-vite4/package/package.json
+++ b/compat-tests/fixtures/basic-vite4/package/package.json
@@ -1,0 +1,20 @@
+{
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@theatre/core": "0.0.1-COMPAT.1",
+    "@theatre/studio": "0.0.1-COMPAT.1"
+  },
+  "browserslist": {
+    "production": [">0.2%", "not dead", "not op_mini all"],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  }
+}

--- a/compat-tests/fixtures/basic-vite4/package/src/index.ts
+++ b/compat-tests/fixtures/basic-vite4/package/src/index.ts
@@ -1,0 +1,9 @@
+import {getProject} from '@theatre/core'
+
+const project = getProject('Sample project')
+const sheet = project.sheet('Scene')
+
+if (import.meta.env.MODE === 'development') {
+  const {default: studio} = await import('@theatre/studio')
+  studio.initialize()
+}

--- a/compat-tests/fixtures/basic-vite4/package/tsconfig.json
+++ b/compat-tests/fixtures/basic-vite4/package/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "include": ["./src/**/*.ts"],
+  "compilerOptions": {
+    "types": ["vite/client"],
+    "moduleResolution": "NodeNext",
+    "module": "NodeNext",
+    "target": "ESNext"
+  }
+}


### PR DESCRIPTION
Adds a basic, framework-agnostic test to the `compat-tests/` directory, using Vite v4. The test is intended to use a "modern JavaScript" workflow with ES Modules, and `tsconfig.json` is configured with:

```json
"moduleResolution": "NodeNext",
"module": "NodeNext",
"target": "ESNext"
```

Currently the code works, but type checking (and the test) will fail.

- related #101 